### PR TITLE
Blockstringsdraft

### DIFF
--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -353,7 +353,7 @@ let ProfileMenu = ({
                 msg`Blocking will not prevent labels from being applied on your account, but it will stop this account from replying in your threads or interacting with you.`,
               )
             : _(
-                msg`Blocking is public. Blocked accounts cannot see your content, reply in your threads, mention you, or otherwise interact with you. You will not see their content.`,
+                msg`Blocking is public. Blocked accounts will be prevented from seeing your content and they cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content.`,
               )
         }
         onConfirm={blockAccount}

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -353,7 +353,7 @@ let ProfileMenu = ({
                 msg`Blocking will not prevent labels from being applied on your account, but it will stop this account from replying in your threads or interacting with you.`,
               )
             : _(
-                msg`Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.`,
+                msg`Blocking is public. Blocked accounts cannot see your content, reply in your threads, mention you, or otherwise interact with you. You will not see their content.`,
               )
         }
         onConfirm={blockAccount}

--- a/src/view/screens/ModerationBlockedAccounts.tsx
+++ b/src/view/screens/ModerationBlockedAccounts.tsx
@@ -118,9 +118,9 @@ export function ModerationBlockedAccounts({}: Props) {
           isTabletOrDesktop && styles.descriptionDesktop,
         ]}>
         <Trans>
-          Blocked accounts cannot reply in your threads, mention you, or
-          otherwise interact with you. You will not see their content and they
-          will be prevented from seeing yours.
+          Blocking is public. Blocked accounts will be prevented from seeing
+          your content and they cannot reply in your threads, mention you, or
+          otherwise interact with you. You will not see their content.
         </Trans>
       </Text>
       {isEmpty ? (

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -630,7 +630,7 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
         control={subscribeBlockPromptControl}
         title={_(msg`Block these accounts?`)}
         description={_(
-          msg`Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.`,
+          msg`Blocking is public. Blocked accounts will be prevented from seeing your content and they cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content.`,
         )}
         onConfirm={onSubscribeBlock}
         confirmButtonCta={_(msg`Block list`)}


### PR DESCRIPTION
Inspired by, I think it might be helpful – especially for new users – to unify and slightly reword the strings explaining how blocks work in the three places that they occur in the app.

These are:

1) When selecting **Block Account** from the menu on a user's profile:

https://github.com/bluesky-social/social-app/blob/5b82b1500720cc959d90471432b84c09d2f86388/src/view/com/profile/ProfileMenu.tsx#L356

2) In **Settings** > **Moderation** > **Blocked Accounts**:

https://github.com/bluesky-social/social-app/blob/5b82b1500720cc959d90471432b84c09d2f86388/src/view/screens/ModerationBlockedAccounts.tsx#L121-L123

3) When selecting **Block List** from the menu on a list page:

https://github.com/bluesky-social/social-app/blob/5b82b1500720cc959d90471432b84c09d2f86388/src/view/screens/ProfileList.tsx#L633

I think the wording I'm suggesting combines the best of all three current strings to clearly explain how blocks work on Bluesky:

**Blocking is public. Blocked accounts will be prevented from seeing your content and they cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content.**