### PR TITLE
update copy in toasts

### DIFF
--- a/src/screens/Settings/SettingsInterests.tsx
+++ b/src/screens/Settings/SettingsInterests.tsx
@@ -120,7 +120,12 @@ function Inner({
         ])
 
         Toast.show(
-          _(msg({message: 'Your interests have been updated!', context: 'toast'})),
+          _(
+            msg({
+              message: 'Your interests have been updated!',
+              context: 'toast',
+            }),
+          ),
         )
       } catch (error) {
         Toast.show(

--- a/src/screens/Settings/SettingsInterests.tsx
+++ b/src/screens/Settings/SettingsInterests.tsx
@@ -120,13 +120,13 @@ function Inner({
         ])
 
         Toast.show(
-          _(msg({message: 'Content preferences updated!', context: 'toast'})),
+          _(msg({message: 'Your interests have been updated!', context: 'toast'})),
         )
       } catch (error) {
         Toast.show(
           _(
             msg({
-              message: 'Failed to save content prefefences.',
+              message: 'Failed to save your interests.',
               context: 'toast',
             }),
           ),


### PR DESCRIPTION
Supersedes #XXXX

As a follow-up to #8114, this PR updates the copy in two toasts:

`Content preferences updated!`
⬇️
`Your interests have been updated!`

`Failed to save content prefefences.`
⬇️
`Failed to save your interests.`