### PR TITLE
Tweak accessibility label

### DIFF
--- a/src/screens/Settings/ContentAndMediaSettings.tsx
+++ b/src/screens/Settings/ContentAndMediaSettings.tsx
@@ -150,7 +150,7 @@ export function ContentAndMediaSettingsScreen({}: Props) {
               </Toggle.Item>
               <Toggle.Item
                 name="show_trending_videos"
-                label={_(msg`Enable trending videos in your Discover feed.`)}
+                label={_(msg`Enable trending videos in your Discover feed`)}
                 value={!trendingVideoDisabled}
                 onChange={value => {
                   const hide = Boolean(!value)


### PR DESCRIPTION
This PR makes a tiny tweak to an accessibility label in `src/screens/Settings/ContentAndMediaSettings.tsx`.

It removes the period/full stop to reduce string duplication and merge it with the `ItemText` string on L167:

`Enable trending videos in your Discover feed.`
⬇️
`Enable trending videos in your Discover feed`