### PR TITLE
Use correct URLs for hashtag search pages generated by `bskyembed`

### DIFF
--- a/bskyembed/src/components/post.tsx
+++ b/bskyembed/src/components/post.tsx
@@ -160,7 +160,7 @@ function PostContent({record}: {record: AppBskyFeedPost.Record | null}) {
       richText.push(
         <Link
           key={counter}
-          href={`/tag/${segment.tag.tag}`}
+          href={`/hashtag/${segment.tag.tag}`}
           className="text-blue-500 hover:underline">
           {segment.text}
         </Link>,


### PR DESCRIPTION
Fixes 8678

This PR implements the fix suggested by paulCapron, I have not tested it though