### PR TITLE
Tweak accessibility label

### DIFF
--- a/src/components/Toast/index.web.tsx
+++ b/src/components/Toast/index.web.tsx
@@ -78,7 +78,9 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({}) => {
           <Toast content={activeToast.content} type={activeToast.type} />
           <Pressable
             style={[a.absolute, a.inset_0]}
-            accessibilityLabel={_(msg`Dismiss toast`)}
+            accessibilityLabel={_(
+              msg({message: 'Dismiss alert', context: 'toast'}),
+            )}
             accessibilityHint=""
             onPress={() => setActiveToast(undefined)}
           />


### PR DESCRIPTION
@nilaallj raised the following issue [on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-sv/7#8734):

> This is an accessibility label, right? I’m not sure if “toast” is a good term to use outside of a developer context. A blind user might not understand what is being dismissed here. Wouldn’t it be better to use something like “message” and maybe “alert” for important toasts?

I'm not too familiar with accessibility guidelines and practices, so I decided to ask Claude, and he did [some helpful research](https://claude.ai/share/99264d01-077f-4ee4-ab28-b2a795e76348).

Given what Claude found, I think referring to a toast as an `alert` might be the most user-friendly option. While either `message` or `notification` could work, given that we already use those words extensively in the UI (and accessibility labels) to mean other things, I think it might not be clear what's being referred to in this context.