### PR TITLE
Add `english-only-resource` context and tweak labels

### DIFF
--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -215,7 +215,7 @@ function ContentHiderActive({
             control.open()
           }}
           label={_(
-            msg`Learn more about the moderation applied to this content.`,
+            msg`Learn more about the moderation applied to this content`,
           )}
           style={[a.pt_sm]}>
           {state => (

--- a/src/components/verification/VerificationsDialog.tsx
+++ b/src/components/verification/VerificationsDialog.tsx
@@ -147,7 +147,12 @@ function Inner({
         <Link
           overridePresentation
           to={urls.website.blog.initialVerificationAnnouncement}
-          label={_(msg`Learn more about verification on Bluesky`)}
+          label={_(
+            msg({
+              message: `Learn more about verification on Bluesky`,
+              context: `english-only-resource`,
+            }),
+          )}
           size="small"
           variant="solid"
           color="secondary"
@@ -162,7 +167,7 @@ function Inner({
             )
           }}>
           <ButtonText>
-            <Trans>Learn more</Trans>
+            <Trans context="english-only-resource">Learn more</Trans>
           </ButtonText>
         </Link>
       </View>

--- a/src/components/verification/VerifierDialog.tsx
+++ b/src/components/verification/VerifierDialog.tsx
@@ -114,7 +114,12 @@ function Inner({
           <Link
             overridePresentation
             to={urls.website.blog.initialVerificationAnnouncement}
-            label={_(msg`Learn more about verification on Bluesky`)}
+            label={_(
+              msg({
+                message: `Learn more about verification on Bluesky`,
+                context: `english-only-resource`,
+              }),
+            )}
             size="small"
             variant="solid"
             color="primary"
@@ -129,7 +134,7 @@ function Inner({
               )
             }}>
             <ButtonText>
-              <Trans>Learn more</Trans>
+              <Trans context="english-only-resource">Learn more</Trans>
             </ButtonText>
           </Link>
           <Button

--- a/src/screens/Moderation/VerificationSettings.tsx
+++ b/src/screens/Moderation/VerificationSettings.tsx
@@ -44,7 +44,12 @@ export function Screen() {
                 <InlineLinkText
                   overridePresentation
                   to={urls.website.blog.initialVerificationAnnouncement}
-                  label={_(msg`Learn more`)}
+                  label={_(
+                    msg({
+                      message: `Learn more`,
+                      context: `english-only-resource`,
+                    }),
+                  )}
                   onPress={() => {
                     logger.metric(
                       'verification:learn-more',

--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -356,9 +356,14 @@ function DialogInner({
                 You are verified. You will lose your verification status if you
                 change your display name.{' '}
                 <InlineLinkText
-                  label={_(msg`Learn more`)}
+                  label={_(
+                    msg({
+                      message: `Learn more`,
+                      context: `english-only-resource`,
+                    }),
+                  )}
                   to={urls.website.blog.initialVerificationAnnouncement}>
-                  <Trans>Learn more.</Trans>
+                  <Trans context="english-only-resource">Learn more.</Trans>
                 </InlineLinkText>
               </Trans>
             </Admonition>

--- a/src/screens/Settings/components/ChangeHandleDialog.tsx
+++ b/src/screens/Settings/components/ChangeHandleDialog.tsx
@@ -209,9 +209,14 @@ function ProvidedHandlePage({
                 You are verified. You will lose your verification status if you
                 change your handle.{' '}
                 <InlineLinkText
-                  label={_(msg`Learn more`)}
+                  label={_(
+                    msg({
+                      message: `Learn more`,
+                      context: `english-only-resource`,
+                    }),
+                  )}
                   to={urls.website.blog.initialVerificationAnnouncement}>
-                  <Trans>Learn more.</Trans>
+                  <Trans context="english-only-resource">Learn more.</Trans>
                 </InlineLinkText>
               </Trans>
             </Admonition>
@@ -268,7 +273,12 @@ function ProvidedHandlePage({
               If you have your own domain, you can use that as your handle. This
               lets you self-verify your identity.{' '}
               <InlineLinkText
-                label={_(msg`learn more`)}
+                label={_(
+                  msg({
+                    message: `Learn more`,
+                    context: `english-only-resource`,
+                  }),
+                )}
                 to="https://bsky.social/about/blog/4-28-2023-domain-handle-tutorial"
                 style={[a.font_bold]}
                 disableMismatchWarning>


### PR DESCRIPTION
This PR proposes adding a `english-only-resource` context to certain strings that link to a blog post, help article, etc which is – for now, at least – only available in English. I think this would provide useful information to translators so that, if they want, they can let the user know that the resource they're about to access has not been localized and is only available in English.

For example, in the French localization, [we have been adding `(en anglais)`](https://bluesky.crowdin.com/editor/1/all/en-fr/7#q=anglais) (meaning _in English_) to the end of translations where we feel it's helpful to let the user know that the blog post or article being linked to is only available in English. Having the `english-only-resource` context on relevant strings would make this easier.

To avoid excessive string churn, this PR only touches some of the relevant strings. If feedback from translators is positive that this is useful and outweighs any inconvenience from string churn, then a future PR could add `english-only-resource` context to other relevant strings.

If there is another context that would be clearer, then I'm open to changing it to something that works better. Here are a few other possible options:
- `english-only`
- `non-localized-resource`
- `not-localized`
- `untranslated-resource`

Also included in this PR are a couple of very minor, unrelated string tweaks to reduce duplication:
- Removing a `.` from a label on L218 in `src/components/moderation/ContentHider.tsx` to align it with the `accessibilityHint` on L152
- Changing `learn more` ➡️ `Learn more` on L271 of `src/screens/Settings/components/ChangeHandleDialog.tsx`