### PR TITLE
Tweak error string, `accessibilityHint`, and comments in `SelectMediaButton.tsx`

### DIFF
--- a/src/view/com/composer/SelectMediaButton.tsx
+++ b/src/view/com/composer/SelectMediaButton.tsx
@@ -484,31 +484,17 @@ export function SelectMediaButton({
           comment: `Accessibility label for button in composer to add photos or a video to a post`,
         }),
       )}
-      accessibilityHint={
-        isNative
-          ? _(
-              msg({
-                message: `Opens device gallery to select up to ${plural(
-                  MAX_IMAGES,
-                  {
-                    other: '# images',
-                  },
-                )}, or a single video.`,
-                comment: `Accessibility hint on native for button in composer to add images or a video to a post. Maximum number of images that can be selected is currently 4 but may change.`,
-              }),
-            )
-          : _(
-              msg({
-                message: `Opens device gallery to select up to ${plural(
-                  MAX_IMAGES,
-                  {
-                    other: '# images',
-                  },
-                )}, or a single video or GIF.`,
-                comment: `Accessibility hint on web for button in composer to add images, a video, or a GIF to a post. Maximum number of images that can be selected is currently 4 but may change.`,
-              }),
-            )
-      }
+      accessibilityHint={_(
+        msg({
+          message: `Opens device gallery to select up to ${plural(
+            MAX_IMAGES,
+            {
+              other: '# images',
+            },
+          )}, or a single video or GIF.`,
+          comment: `Accessibility hint for button in composer to add images, a video, or a GIF to a post. Maximum number of images that can be selected is currently 4 but may change.`,
+        }),
+      )}
       style={a.p_sm}
       variant="ghost"
       shape="round"

--- a/src/view/com/composer/SelectMediaButton.tsx
+++ b/src/view/com/composer/SelectMediaButton.tsx
@@ -410,7 +410,7 @@ export function SelectMediaButton({
             msg`You can only select one GIF at a time.`,
           ),
           [SelectedAssetError.FileTooBig]: _(
-            msg`One or more of your selected files is too large. Maximum size is 100 MB.`,
+            msg`One or more of your selected files are too large. Maximum size is 100 MB.`,
           ),
         }[error]
       })

--- a/src/view/com/composer/SelectMediaButton.tsx
+++ b/src/view/com/composer/SelectMediaButton.tsx
@@ -481,7 +481,7 @@ export function SelectMediaButton({
       label={_(
         msg({
           message: `Add media to post`,
-          comment: `Accessibility label for button in composer to add photos or a video to a post`,
+          comment: `Accessibility label for button in composer to add images, a video, or a GIF to a post`,
         }),
       )}
       accessibilityHint={_(

--- a/src/view/com/composer/SelectMediaButton.tsx
+++ b/src/view/com/composer/SelectMediaButton.tsx
@@ -486,12 +486,9 @@ export function SelectMediaButton({
       )}
       accessibilityHint={_(
         msg({
-          message: `Opens device gallery to select up to ${plural(
-            MAX_IMAGES,
-            {
-              other: '# images',
-            },
-          )}, or a single video or GIF.`,
+          message: `Opens device gallery to select up to ${plural(MAX_IMAGES, {
+            other: '# images',
+          })}, or a single video or GIF.`,
           comment: `Accessibility hint for button in composer to add images, a video, or a GIF to a post. Maximum number of images that can be selected is currently 4 but may change.`,
         }),
       )}


### PR DESCRIPTION
After seeing the new strings that were added in #8828 appear on Crowdin, I noticed a few things that I'd previously missed.

So this PR suggests a few tweaks:

- As Claude reminded me when I checked: "_With the phrase “one or more,” standard English grammar calls for plural verb agreement._" So the `FileTooBig` error string should read `One or more of your selected files are too large. …` rather than `… is too large. …`, similar to the `Unsupported` error string.
- Now that GIFs are supported on native too, there's no need for the `isNative` check in the `accessibilityHint`, so I suggest removing the check and consequently simplifying the `accessibilityHint` slightly.
- A minor tweak to the comment for translators for the `Add media to post` label to use the same language as the `accessibilityHint`.