### PR TITLE
Add context for translators and tweak strings

### DIFF
--- a/src/components/dms/ReactionsDialog.tsx
+++ b/src/components/dms/ReactionsDialog.tsx
@@ -357,7 +357,7 @@ function ReactionTab({
       accessibilityRole="button"
       accessibilityHint={
         reaction.key === 'all'
-          ? l`Tap to show all reactions `
+          ? l`Tap to show all reactions`
           : l`Tap to show ${reaction.value} reactions`
       }
       hitSlop={HITSLOP_10}

--- a/src/screens/Messages/ConversationSettings.tsx
+++ b/src/screens/Messages/ConversationSettings.tsx
@@ -651,7 +651,7 @@ function MemberMenu({
               label={l`Message ${displayName}`}
               onPress={handleMessageMember}>
               <Menu.ItemText>
-                <Trans>Message</Trans>
+                <Trans context="action">Message</Trans>
               </Menu.ItemText>
               <Menu.ItemIcon icon={MessageIcon} />
             </Menu.Item>

--- a/src/screens/Messages/ConversationSettings.tsx
+++ b/src/screens/Messages/ConversationSettings.tsx
@@ -1076,7 +1076,7 @@ function InviteLinkPrompt({
     <Prompt.Basic
       control={control}
       title={l`Invite link`}
-      description={l`An invite link lets people join this group chat without being added directly. You control who can use the link and whether they need your approval. You can disable the link at any time. Your name, avatar, and the name of the group chat will be visible to everyone`}
+      description={l`An invite link lets people join this group chat without being added directly. You control who can use the link and whether they need your approval. You can disable the link at any time. Your name, avatar, and the name of the group chat will be visible to everyone.`}
       confirmButtonCta={l`Get started`}
       cancelButtonCta={l`Cancel`}
       onConfirm={onConfirm}


### PR DESCRIPTION
This PR proposes three small changes to strings related to group clip clops that were recently added.

1. Adds `context` to the `Message` string in the menu showing options for each chat member to make it clear that it's an `action`. This is important to provide accurate translations because the three pre-existing usages of the `Message` string refer to the noun rather than the verb.
2. Removes the trailing space from one of the `accessibilityHint`s in the reactions dialog.
3. Adds a period to the end of the invite link prompt description string.