### PR TITLE
Update 'Moderation' screen title to include 'and Content Filters'

### DIFF
--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -97,7 +97,7 @@ export function ModerationScreen(
         <Layout.Header.BackButton />
         <Layout.Header.Content>
           <Layout.Header.TitleText>
-            <Trans>Moderation</Trans>
+            <Trans>Moderation and Content Filters</Trans>
           </Layout.Header.TitleText>
         </Layout.Header.Content>
         <Layout.Header.Slot />


### PR DESCRIPTION
As a follow-up to 10192, this PR proposes updating the title on the Moderation screen to match. Titles on Settings screens use title case rather than sentence case as on the main Settings screen, so I have followed that here.