### PR TITLE
Add security policy in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security disclosures
+
+If you discover any security issues, please send an email to security@bsky.app. The email is automatically CC'd to the entire team and we'll respond promptly.


### PR DESCRIPTION
Someone mentioned on Bluesky that they couldn't see a security policy for the `social-app` repo. So I think it might be helpful to create a `SECURITY.md` file that will be shown on the dedicated [Security and quality page](https://github.com/bluesky-social/social-app/security), to complement the [**Security disclosures** section in the README](https://github.com/bluesky-social/social-app#security-disclosures).

This PR adds `SECURITY.md` with the content being the same text from the `README`.