### PR TITLE
Tweak location strings

### DIFF
--- a/src/ageAssurance/components/NoAccessScreen.tsx
+++ b/src/ageAssurance/components/NoAccessScreen.tsx
@@ -394,11 +394,11 @@ function AccessSection() {
                 <Trans>
                   Is your location not accurate?{' '}
                   <SimpleInlineLinkText
-                    label={_(msg`Confirm your location`)}
+                    label={_(msg`Update your location`)}
                     {...createStaticClick(() => {
                       locationControl.open()
                     })}>
-                    Tap here to confirm your location.
+                    Tap here to update your location with GPS.
                   </SimpleInlineLinkText>{' '}
                 </Trans>
               </Admonition>

--- a/src/components/ageAssurance/AgeAssuranceAccountCard.tsx
+++ b/src/components/ageAssurance/AgeAssuranceAccountCard.tsx
@@ -275,11 +275,11 @@ function RegionNotice() {
         <Text style={[a.text_sm, a.leading_snug]}>
           <Trans>
             <InlineLinkText
-              label={l`Confirm your location`}
+              label={l`Update your location`}
               {...createStaticClick(() => {
                 locationControl.open()
               })}>
-              Tap here to confirm your location.
+              Tap here to update your location with GPS.
             </InlineLinkText>
           </Trans>
         </Text>

--- a/src/components/dialogs/DeviceLocationRequestDialog.tsx
+++ b/src/components/dialogs/DeviceLocationRequestDialog.tsx
@@ -38,7 +38,7 @@ export function DeviceLocationRequestDialog({
       <Dialog.Handle />
 
       <Dialog.ScrollableInner
-        label={_(msg`Confirm your location`)}
+        label={_(msg`Update your location`)}
         style={[web({maxWidth: 380})]}>
         <DeviceLocationRequestDialogInner
           onLocationAcquired={onLocationAcquired}
@@ -103,7 +103,7 @@ function DeviceLocationRequestDialogInner({onLocationAcquired}: Props) {
   return (
     <View style={[a.gap_md]}>
       <Text style={[a.text_xl, a.font_bold]}>
-        <Trans>Confirm your location</Trans>
+        <Trans>Update your location</Trans>
       </Text>
       <View style={[a.gap_sm, a.pb_xs]}>
         <Text style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>

--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -327,11 +327,11 @@ export function StepInfo({
                             <Trans>
                               Have we got your location wrong?{' '}
                               <SimpleInlineLinkText
-                                label={l`Tap here to confirm your location with GPS.`}
+                                label={l`Tap here to update your location with GPS.`}
                                 {...createStaticClick(() => {
                                   locationControl.open()
                                 })}>
-                                Tap here to confirm your location with GPS.
+                                Tap here to update your location with GPS.
                               </SimpleInlineLinkText>
                             </Trans>
                           </Admonition.Text>


### PR DESCRIPTION
In response to [feedback on Discord](https://discord.com/channels/1338165055992107061/1338165056596082731/1503747994640715907), this PR proposes tweaking five age assurance strings related to location from `Confirm your location` to `Update your location`.

As an example of somewhere else that similar copy is used, Google has an `Update location` link in the footer of search results pages on mobile which performs a similar function: it prompts the user to grant access to device geolocation.


<img width="517" height="302" alt="IMG_2170" src="https://github.com/user-attachments/assets/852357d2-d8b3-41b6-b1db-610efce11690" />


Also, this PR proposes adding `with GPS.` to the end of strings that don't currently include it, because I believe it would be helpful to make that clear to users before the dialog is shown.