### PR TITLE
Fix incorrect "under 18" admonition on Moderation screen

### DIFF
--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -41,6 +41,7 @@ const AgeAssuranceStateContext = createContext<{
   flags: {
     adultContentDisabled: boolean
     chatDisabled: boolean
+    isDeclaredUnderAdultAge: boolean
     isOverRegionMinAccessAge: boolean
     isOverAppMinAccessAge: boolean
   }
@@ -55,6 +56,7 @@ const AgeAssuranceStateContext = createContext<{
   flags: {
     adultContentDisabled: false,
     chatDisabled: false,
+    isDeclaredUnderAdultAge: false,
     isOverRegionMinAccessAge: false,
     isOverAppMinAccessAge: false,
   },
@@ -109,6 +111,9 @@ function InnerProvider({children}: {children: React.ReactNode}) {
         const isUnderAdultAge = data?.birthdate
           ? isUnderAge(data.birthdate, 18)
           : true
+        const isDeclaredUnderAdultAge = data?.birthdate
+          ? isUnderAge(data.birthdate, 18)
+          : false
         const isOverRegionMinAccessAge = data?.birthdate
           ? !isUnderAge(data.birthdate, config.minAccessAge)
           : false
@@ -124,6 +129,7 @@ function InnerProvider({children}: {children: React.ReactNode}) {
           flags: {
             adultContentDisabled,
             chatDisabled,
+            isDeclaredUnderAdultAge,
             isOverRegionMinAccessAge,
             isOverAppMinAccessAge,
           },

--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -225,7 +225,7 @@ export function ModerationScreenInner({
 
   return (
     <View style={[a.pt_2xl, a.px_lg, gtMobile && a.px_2xl]}>
-      {aa.flags.adultContentDisabled && isBirthdateUpdateAllowed && (
+      {aa.flags.isDeclaredUnderAdultAge && isBirthdateUpdateAllowed && (
         <View style={[a.pb_2xl]}>
           <Admonition.Admonition type="tip" style={[a.pb_md]}>
             <Trans>


### PR DESCRIPTION
Fixes 10520

> [!IMPORTANT]
> **Claude Code analysed this bug and wrote the PR and most of the description. Although it passes CI, I have not tested the fix.**

### The bug

In `src/screens/Moderation/index.tsx:228`, the "Your declared age is under 18" admonition is shown when `aa.flags.adultContentDisabled` is true.

But looking at `src/ageAssurance/index.tsx:118-119`:

```tsx
const adultContentDisabled =
  state.access !== AgeAssuranceAccess.Full || isUnderAdultAge
```

`adultContentDisabled` is true under **two different conditions**:
1. The user's declared age is under 18 (`isUnderAdultAge`)
2. **OR** the user is accessing Bluesky in a region requiring age assurance and hasn't completed it (`state.access !== AgeAssuranceAccess.Full`)

So an adult user who has set their birthdate correctly but is accessing Bluesky in a region requiring age assurance — and hasn't completed it yet — gets `adultContentDisabled = true` via condition 2, and is then incorrectly shown the "Your declared age is under 18" message.

### The fix
- Added a separate `isDeclaredUnderAdultAge` flag on the age assurance context that is `true` only when there is a declared birthdate that resolves to under 18 (defaults to `false` if no birthdate is known, unlike `isUnderAdultAge` which defaults to `true` for the "safe by default" semantics that `adultContentDisabled` needs).
- Changed `src/screens/Moderation/index.tsx:228` to gate the admonition on `aa.flags.isDeclaredUnderAdultAge` instead of `aa.flags.adultContentDisabled`.