### PR TITLE
Improve logic to show most relevant error message in AA restricted regions

### DIFF
--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -308,15 +308,15 @@ export function StepInfo({
                     <Admonition.Icon />
                     <Admonition.Content>
                       <Admonition.Text>
-                        {!isOverAppMinAccessAge ? (
-                          <Plural
-                            value={MIN_ACCESS_AGE}
-                            other="You must be # years of age or older to create an account."
-                          />
-                        ) : (
+                        {aaRegionConfig.minAccessAge > MIN_ACCESS_AGE ? (
                           <Plural
                             value={aaRegionConfig.minAccessAge}
                             other="You must be # years of age or older to create an account in your region."
+                          />
+                        ) : (
+                          <Plural
+                            value={MIN_ACCESS_AGE}
+                            other="You must be # years of age or older to create an account."
                           />
                         )}
                       </Admonition.Text>


### PR DESCRIPTION
## Issue

When creating a new account in a region that has a stricter minimum age (_x_) than the global minimum age of 13, a user who enters a birthdate that computes to an age below 13 is shown the global "must be 13" message instead of the regional "must be _x_" message, which is what is actually relevant. This might be confusing.

To use a concrete example: the minimum age in Australia is 16, and if a user enters a birthdate that computes to an age of 13-15, they are correctly shown a message saying that the minimum age in their region is 16:

<img width="603" height="333" alt="IMG_2208" src="https://github.com/user-attachments/assets/37ce5516-12d7-4733-8642-c863042657e4" />

However, if the user enters a birthdate that computes to an age of under 13, they are shown a message saying that the minimum age is 13, despite the minimum age in their region actually being 16:

<img width="603" height="280" alt="IMG_2207" src="https://github.com/user-attachments/assets/73029874-4a7a-43a3-9498-40cc8e6f575b" />

## Root cause

This happens because the nested conditional at `src/screens/Signup/StepInfo/index.tsx:311` selects which error message to show based on **which threshold the user falls under** rather than **which threshold applies in the region**. For an Australian user under 13:

- `isOverAppMinAccessAge` → false (under 13)
- `isOverRegionMinAccessAge` → false (under 16)

The nested ternary checks `!isOverAppMinAccessAge` first, which is `true`, so it renders the global "13+" message — even though the regional 16+ requirement is what actually gates them.

## Fix

This logic can be improved by changing the inner ternary to switch on the region config itself: when `aaRegionConfig.minAccessAge > MIN_ACCESS_AGE`, always show the regional message; otherwise show the global one. Any birthdate that computes to an age below the regional minimum now consistently shows the regional error message in restricted regions (e.g., Australia gets the 16+ message for both a 12-year-old and a 15-year-old).
