### PR TITLE
Fix search bar placeholder wrapping on Android with larger fonts

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -266,6 +266,10 @@ export function createInput(Component: typeof TextInput) {
             ctx.onBlur()
             onBlur?.(e)
           }}
+          // Single-line inputs must stay on one line. Without this, Android can
+          // wrap a placeholder that is wider than the field onto multiple lines
+          // (notably after the field is cleared), growing the input height.
+          numberOfLines={rest.numberOfLines ?? (rest.multiline ? undefined : 1)}
           placeholder={placeholder === null ? undefined : placeholder || label}
           placeholderTextColor={t.palette.contrast_500}
           keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}


### PR DESCRIPTION
Single-line TextField.Input never set numberOfLines, so on Android a placeholder wider than the field (e.g. the Explore search bar with Default/Larger font sizes) could wrap onto multiple lines after the field was cleared, growing the input height. Enforce single-line rendering for non-multiline inputs while respecting an explicit numberOfLines and leaving multiline inputs untouched.

Fixes 8181

https://claude.ai/code/session_01XQdLbxXXH4wyzxRk6JgVpv