### PR TITLE
Fix search bar placeholder wrapping on Android

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -266,6 +266,10 @@ export function createInput(Component: typeof TextInput) {
             ctx.onBlur()
             onBlur?.(e)
           }}
+          // Single-line inputs must stay on one line. Without this, Android can
+          // wrap a placeholder that is wider than the field onto multiple lines
+          // (notably after the field is cleared), growing the input height.
+          numberOfLines={rest.numberOfLines ?? (rest.multiline ? undefined : 1)}
           placeholder={placeholder === null ? undefined : placeholder || label}
           placeholderTextColor={t.palette.contrast_500}
           keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}


### PR DESCRIPTION
> [!IMPORTANT]
> **Claude Code analyzed this issue and wrote the PR and much of the description. Although it passes CI, I have not tested the fix.**

Fixes 8181

## Root cause

The **Explore** search bar uses a long placeholder, `Search for posts, users, or feeds` (`src/screens/Search/Shell.tsx:387`). It's built on the shared `TextField.Input` (`createInput`) in `src/components/forms/TextField.tsx`, which renders a **single-line** `TextInput` (no `multiline`) but never set `numberOfLines={1}`.

On Android, depending on screen size and font size settings, a single-line `TextInput` whose placeholder is wider than the available width can **wrap the placeholder onto multiple lines** — and the wrap is re-triggered when the field is cleared after holding text. That's the inconsistency in issue 8181: clipped to one line on first focus, then wrapped to two lines (growing the input height) after typing and clearing.

## Fix

One line in the shared input (`src/components/forms/TextField.tsx`):

```tsx
numberOfLines={rest.numberOfLines ?? (rest.multiline ? undefined : 1)}
```

This enforces single-line rendering for all single-line `TextField.Input`s while:
- leaving `multiline` inputs untouched (they keep wrapping + `minHeight: 80`), and
- respecting any explicitly-passed `numberOfLines`.

It's a no-op on iOS single-line inputs and ignored for non-multiline inputs on web, so it's safe cross-platform.

## Test plan

- Following the steps in 8181, check that placeholder text is truncated rather than wrapping onto a second line after clearing input in the Explore search bar.