### PR TITLE
Use correct `Plural` macro in InviteLinkDialog

### DIFF
--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -5,8 +5,7 @@ import {
   moderateProfile,
   type ModerationOpts,
 } from '@atproto/api'
-import {plural} from '@lingui/core/macro'
-import {Trans, useLingui} from '@lingui/react/macro'
+import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
@@ -178,10 +177,10 @@ export function InviteLinkDialog({
             <Text style={[a.text_md, a.leading_snug]}>
               <Trans>
                 Group chats can only have a maximum of{' '}
-                {plural(convo.details.memberLimit, {
-                  one: '# person',
-                  other: '# people',
-                })}
+                <Plural
+                  value={convo.details.memberLimit}
+                  other="# people"
+                />
                 .
               </Trans>
             </Text>

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -177,11 +177,7 @@ export function InviteLinkDialog({
             <Text style={[a.text_md, a.leading_snug]}>
               <Trans>
                 Group chats can only have a maximum of{' '}
-                <Plural
-                  value={convo.details.memberLimit}
-                  other="# people"
-                />
-                .
+                <Plural value={convo.details.memberLimit} other="# people" />.
               </Trans>
             </Text>
             <Text style={[a.text_md, a.leading_snug]}>


### PR DESCRIPTION
> [!IMPORTANT]
> **Claude Code analyzed this issue and wrote the PR and much of the description.**
> 
> **I asked Claude to double-check this PR so I hope that this time the code is actually correct** 🤞
>
> **Although it passes CI, I have not tested the fix.**

## Problem

Sorry, this was my bad. In 10638 I suggested adding plural formatting for the string at `src/screens/Messages/components/InviteLinkDialog.tsx:179` with the code that Claude Code gave me, which used the JS `plural` macro (`@lingui/core/macro`) inside a `<Trans>` element:

```tsx
<Trans>
  Group chats can only have a maximum of{' '}
  {plural(convo.details.memberLimit, { one: '# person', other: '# people' })}
  .
</Trans>
```

The result is that the string can't be properly localized on Crowdin and I assume won't display properly:

<img width="600" alt="IMG_9082" src="https://github.com/user-attachments/assets/b16312e2-b5eb-48a7-b1f8-0802b7183771" />

___

`@lingui/core/macro`'s `plural` is meant to produce a *standalone* translated string (`i18n._(...)`). When nested inside `<Trans>` as an expression container, the `<Trans>` macro doesn't inline it — it treats the whole `{plural(...)}` as an opaque placeholder and names it `{0}`. This is why in the Crowdin screenshot it shows: `Group chats can only have a maximum of {0}.`, with the plural forms (`# person` / `# people`) dropped from the translatable message so translators can't localize them.

## Fix

Switch to the **`<Plural>` JSX macro** from `@lingui/react/macro`, which `<Trans>` knows how to inline into a single ICU message:

```tsx
<Trans>
  Group chats can only have a maximum of{' '}
  <Plural value={convo.details.memberLimit} other="# people" />.
</Trans>
```

This extracts as one properly localizable message:

> Group chats can only have a maximum of {memberLimit, plural, other {# people}}.

(The `one` form seems unnecessary to include as a group chat will by definition always have more than one member, so that situation will never occur in the source locale – English.)

The now-unused `import {plural} from '@lingui/core/macro'` can be removed (it was the only usage in the file).