### PR TITLE
Add plural formatting to "Group name is too long" strings

### DIFF
--- a/src/components/dms/InitiateChatFlow.tsx
+++ b/src/components/dms/InitiateChatFlow.tsx
@@ -600,12 +600,11 @@ export function InitiateChatFlow({
                       {color: t.palette.negative_400},
                     ]}>
                     <Trans>
-                      Group name is too long. The maximum length is{' '}
+                      Group name is too long.{' '}
                       <Plural
                         value={MAX_GROUP_NAME_GRAPHEME_LENGTH}
-                        other="# characters"
+                        other="The maximum length is # characters."
                       />
-                      .
                     </Trans>
                   </Text>
                 ) : null}

--- a/src/components/dms/InitiateChatFlow.tsx
+++ b/src/components/dms/InitiateChatFlow.tsx
@@ -603,7 +603,7 @@ export function InitiateChatFlow({
                       Group name is too long.{' '}
                       <Plural
                         value={MAX_GROUP_NAME_GRAPHEME_LENGTH}
-                        other="The maximum length is # characters."
+                        other="The maximum number of characters is #."
                       />
                     </Trans>
                   </Text>

--- a/src/components/dms/InitiateChatFlow.tsx
+++ b/src/components/dms/InitiateChatFlow.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import {LayoutAnimation, type TextInput, View} from 'react-native'
 import {moderateProfile, type ModerationOpts} from '@atproto/api'
-import {Trans, useLingui} from '@lingui/react/macro'
+import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
 import {MAX_GROUP_NAME_GRAPHEME_LENGTH} from '#/lib/constants'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
@@ -600,8 +600,12 @@ export function InitiateChatFlow({
                       {color: t.palette.negative_400},
                     ]}>
                     <Trans>
-                      Group name is too long. The maximum number of characters
-                      is {MAX_GROUP_NAME_GRAPHEME_LENGTH}.
+                      Group name is too long. The maximum length is{' '}
+                      <Plural
+                        value={MAX_GROUP_NAME_GRAPHEME_LENGTH}
+                        other="# characters"
+                      />
+                      .
                     </Trans>
                   </Text>
                 ) : null}

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -1,5 +1,5 @@
 import {View} from 'react-native'
-import {Trans, useLingui} from '@lingui/react/macro'
+import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
 import {MAX_GROUP_NAME_GRAPHEME_LENGTH} from '#/lib/constants'
 import {isOverMaxGraphemeCount} from '#/lib/strings/helpers'
@@ -59,8 +59,12 @@ export function EditNamePrompt({
                   {color: t.palette.negative_400},
                 ]}>
                 <Trans>
-                  Group name is too long. The maximum number of characters is{' '}
-                  {MAX_GROUP_NAME_GRAPHEME_LENGTH}.
+                  Group name is too long. The maximum length is{' '}
+                  <Plural
+                    value={MAX_GROUP_NAME_GRAPHEME_LENGTH}
+                    other="# characters"
+                  />
+                  .
                 </Trans>
               </Text>
             ) : null}

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -59,12 +59,11 @@ export function EditNamePrompt({
                   {color: t.palette.negative_400},
                 ]}>
                 <Trans>
-                  Group name is too long. The maximum length is{' '}
+                  Group name is too long.{' '}
                   <Plural
                     value={MAX_GROUP_NAME_GRAPHEME_LENGTH}
-                    other="# characters"
+                    other="The maximum length is # characters."
                   />
-                  .
                 </Trans>
               </Text>
             ) : null}

--- a/src/screens/Messages/ConversationSettings/prompts.tsx
+++ b/src/screens/Messages/ConversationSettings/prompts.tsx
@@ -62,7 +62,7 @@ export function EditNamePrompt({
                   Group name is too long.{' '}
                   <Plural
                     value={MAX_GROUP_NAME_GRAPHEME_LENGTH}
-                    other="The maximum length is # characters."
+                    other="The maximum number of characters is #."
                   />
                 </Trans>
               </Text>


### PR DESCRIPTION
This PR adds plural formatting for the two `Group name is too long` error strings following the pattern used for similar "too long" strings.

`MAX_GROUP_NAME_GRAPHEME_LENGTH` is currently `50` (`src/lib/constants.ts:70`) and the limit will always be greater than 1, so as in other similar instances, only the `other` prop is included as that is the only plural form relevant in the source locale, English. That will also be the only relevant plural form for translations in most other locales. However, adding plural formatting means that these strings are able to be correctly localized by translators in all supported locales.