### PR TITLE
Fix hashtag author filter failing for DIDs

### DIFF
--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -121,7 +121,9 @@ export default function HashtagScreen({
                 <Layout.Header.TitleText>{headerTitle}</Layout.Header.TitleText>
                 {author && (
                   <Layout.Header.SubtitleText>
-                    {_(msg`From @${sanitizedAuthor}`)}
+                    {author.startsWith('did:')
+                      ? _(msg`From ${sanitizedAuthor}`)
+                      : _(msg`From @${sanitizedAuthor}`)}
                   </Layout.Header.SubtitleText>
                 )}
               </Layout.Header.Content>
@@ -172,11 +174,9 @@ function HashtagScreenTab({
   const isCashtag = fullTag.startsWith('$')
 
   const queryParam = useMemo(() => {
-    // Cashtags need # prefix for search: "#$BTC" or "#$BTC from:author"
-    const searchTag = isCashtag ? `#${fullTag}` : fullTag
-    if (!author) return searchTag
-    return `${searchTag} from:${author}`
-  }, [fullTag, author, isCashtag])
+    // Cashtags need # prefix for search: "#$BTC"
+    return isCashtag ? `#${fullTag}` : fullTag
+  }, [fullTag, isCashtag])
 
   const {
     data,
@@ -188,7 +188,7 @@ function HashtagScreenTab({
     refetch,
     fetchNextPage,
     hasNextPage,
-  } = useSearchPostsQuery({query: queryParam, sort, enabled: active})
+  } = useSearchPostsQuery({query: queryParam, sort, enabled: active, author})
 
   const posts = useMemo(() => {
     return data?.pages.flatMap(page => page.posts) || []

--- a/src/state/queries/search-posts.ts
+++ b/src/state/queries/search-posts.ts
@@ -22,29 +22,35 @@ import {
 } from './util'
 
 const searchPostsQueryKeyRoot = 'search-posts'
-const searchPostsQueryKey = ({query, sort}: {query: string; sort?: string}) => [
-  searchPostsQueryKeyRoot,
+const searchPostsQueryKey = ({
   query,
   sort,
-]
+  author,
+}: {
+  query: string
+  sort?: string
+  author?: string
+}) => [searchPostsQueryKeyRoot, query, sort, author]
 
 export function useSearchPostsQuery({
   query,
   sort,
   enabled,
+  author,
 }: {
   query: string
   sort?: 'top' | 'latest'
   enabled?: boolean
+  author?: string
 }) {
   const agent = useAgent()
   const moderationOpts = useModerationOpts()
   const selectArgs = useMemo(
     () => ({
-      isSearchingSpecificUser: /from:(\w+)/.test(query),
+      isSearchingSpecificUser: !!author || /from:(\w+)/.test(query),
       moderationOpts,
     }),
-    [query, moderationOpts],
+    [query, author, moderationOpts],
   )
   const lastRun = useRef<{
     data: InfiniteData<AppBskyFeedSearchPosts.OutputSchema>
@@ -59,13 +65,14 @@ export function useSearchPostsQuery({
     QueryKey,
     string | undefined
   >({
-    queryKey: searchPostsQueryKey({query, sort}),
+    queryKey: searchPostsQueryKey({query, sort, author}),
     queryFn: async ({pageParam}) => {
       const res = await agent.app.bsky.feed.searchPosts({
         q: query,
         limit: 25,
         cursor: pageParam,
         sort,
+        author,
       })
       return res.data
     },


### PR DESCRIPTION
## Context

A related issue in 6400 was fixed by 9948 but the core issue that was originally described still exists. This PR aims to fix the originally described issue by allowing hashtag search pages to be filtered by DID-based author.

## The Problem

When navigating to a hashtag URL with a DID-based author filter (e.g. `https://bsky.app/hashtag/muzika?author=did:plc:nr4a7ddupzvwpfv5sxklmkqh`), the author filter is silently ignored – the header shows `From @did:plc:...` but the search results are unfiltered, showing posts from all authors.

The header also incorrectly shows an `@` before the DID.

## Root Cause

The `HashtagScreenTab` component constructs a freeform query string like:

```
#muzika from:did:plc:nr4a7ddupzvwpfv5sxklmkqh
```

and passes it as the `q` parameter to `app.bsky.feed.searchPosts`. The search backend uses Lucene-style query parsing, and the colons in the DID (`did:plc:xxx`) cause the parser to misinterpret the `from:` operator (it appears to read `from:did` as the value and discard the rest), so the filter is dropped.

Handles don't contain colons, so `from:sutnistj.bsky.social` parses correctly – which is why the handle case works.

## The Fix

### Use the dedicated `author` API parameter

The `app.bsky.feed.searchPosts` endpoint already has a dedicated `author` parameter (type: `at-identifier`) that properly accepts both handles and DIDs. From the [lexicon](https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/searchPosts.json):

> Filter to posts by the given account. Handles are resolved to DID before query-time.

Instead of stuffing `from:{author}` into `q`, this PR passes `author` as a first-class API parameter, letting the backend handle filtering for both handles and DIDs.

### Omit `@` prefix for DIDs in the header

The subtitle now checks whether `author` starts with `did:` and conditionally omits the `@` prefix, so DIDs display as `From did:plc:xxx` instead of `From @did:plc:xxx`.

## Key Changes

- **Updated `searchPostsQueryKey`**: Added `author` as an optional parameter to the query key function so each author filter gets a distinct cache entry
- **Extended `useSearchPostsQuery` hook**: Added optional `author` parameter that gets passed directly to the API call
- **Updated query dependency tracking**: Added `author` to the `selectArgs` useMemo dependency array and updated the condition for detecting user-specific searches to check for the `author` parameter
- **Refactored `HashtagScreenTab`**: 
  - Removed the logic that appended `from:${author}` to the search query string
  - Now passes `author` as a separate parameter to `useSearchPostsQuery`
  - Simplified `queryParam` to only handle the hashtag/cashtag formatting
- **Improved author display**: Updated the subtitle text in `HashtagScreen` to conditionally format the author display so that the `@` prefix is only shown for handles and not for DIDs

## Testing

| Scenario | Before | After |
|---|---|---|
| `?author=did:plc:xxx` – results | Unfiltered | ✅ Correctly filtered |
| `?author=did:plc:xxx` – header | `From @did:plc:xxx` | ✅ `From did:plc:xxx` |
| `?author=sutnistj.bsky.social` – results | Works | ✅ Works (now via dedicated param) |