### PR TITLE
Add i18n context to gallery and group chat member count badges

### DIFF
--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -523,7 +523,11 @@ function GalleryImage({
                   a.font_bold,
                   largeAltBadge ? a.text_xs : {fontSize: 8},
                 ]}>
-                {index + 1}/{imageCount}
+                <Trans
+                  context="gallery-badge-numbers"
+                  comment="Badge showing the current image position out of the total number of images in a gallery, e.g. 1/3.">
+                  {index + 1}/{imageCount}
+                </Trans>
               </Text>
             </View>
           ) : null}

--- a/src/screens/Messages/JoinRequest.tsx
+++ b/src/screens/Messages/JoinRequest.tsx
@@ -127,7 +127,9 @@ export function JoinRequest({setScreenState}: Props) {
                         a.leading_snug,
                         t.atoms.text_contrast_medium,
                       ]}>
-                      <Trans comment="The number of active group chat members out of the total number allowed.">
+                      <Trans
+                        context="group-chat-member-numbers"
+                        comment="The number of active group chat members out of the total number allowed.">
                         {data.joinLinkPreviews[0].memberCount}/
                         {data.joinLinkPreviews[0].memberLimit}
                       </Trans>


### PR DESCRIPTION
## Summary

Added internationalization context annotations to two numeric badge strings to improve translation clarity and consistency.

## Changes

- **Gallery image position badge** (`src/components/images/Gallery/index.tsx`): Wrapped the "current/total" image count display with a `<Trans>` component that includes a `context` attribute (`gallery-badge-numbers`) and a descriptive comment explaining the badge format (e.g., "1/3").

- **Group chat member count badge** (`src/screens/Messages/JoinRequest.tsx`): Added `context` attribute (`group-chat-member-numbers`) to the existing `<Trans>` component wrapping the member count display, improving the translation context for translators.

## Implementation Details

These changes follow Lingui 5 i18n best practices by providing additional context to translators through the `context` attribute. This helps ensure consistent and accurate translations of numeric badges that may have different formatting requirements across languages. The comments provide examples of the expected output format.

https://claude.ai/code/session_015iC27apVDba8tL7KuZQrXu