### PR TITLE
Mark string for translation and add context

### DIFF
--- a/src/components/images/Gallery/index.tsx
+++ b/src/components/images/Gallery/index.tsx
@@ -523,7 +523,11 @@ function GalleryImage({
                   a.font_bold,
                   largeAltBadge ? a.text_xs : {fontSize: 8},
                 ]}>
-                {index + 1}/{imageCount}
+                <Trans
+                  context="gallery-badge-image-position-numbers"
+                  comment="Badge showing the current image position out of the total number of images in a gallery.">
+                  {index + 1}/{imageCount}
+                </Trans>
               </Text>
             </View>
           ) : null}

--- a/src/screens/Messages/JoinRequest.tsx
+++ b/src/screens/Messages/JoinRequest.tsx
@@ -127,7 +127,9 @@ export function JoinRequest({setScreenState}: Props) {
                         a.leading_snug,
                         t.atoms.text_contrast_medium,
                       ]}>
-                      <Trans comment="The number of active group chat members out of the total number allowed.">
+                      <Trans
+                        context="group-chat-member-count"
+                        comment="The number of active group chat members out of the total number allowed.">
                         {data.joinLinkPreviews[0].memberCount}/
                         {data.joinLinkPreviews[0].memberLimit}
                       </Trans>


### PR DESCRIPTION
Fixes 10804

This PR marks for translation the string that shows the position count of images in a gallery on badges (e.g. `2/5`) so that translators can localize this as needed (e.g. reversing the order in Hungarian as smileyhead discussed in 10804).

It also adds `context` to the string in the join request screen which will have an identical message id after extraction, so that different translations can be provided for each string as needed.