### PR TITLE
Use 'hyphens' instead of 'dashes' in error string

### DIFF
--- a/src/screens/Settings/components/AddAppPasswordDialog.tsx
+++ b/src/screens/Settings/components/AddAppPasswordDialog.tsx
@@ -59,7 +59,7 @@ function CreateDialogInner({passwords}: {passwords: string[]}) {
     () =>
       new DisplayableError(
         _(
-          msg`App password names can only contain letters, numbers, spaces, dashes, and underscores`,
+          msg`App password names can only contain letters, numbers, spaces, hyphens, and underscores`,
         ),
       ),
     [_],


### PR DESCRIPTION
Fixes 11048

In response to [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-engb/9?view=comfortable#347), this PR proposes changing `dashes` to `hyphens` in this error string in the app password dialog:

`App password names can only contain letters, numbers, spaces, dashes, and underscores`

Although `dashes` will be understood as colloquially referring to the ASCII hyphen-minus character (`-`) by most English speakers, `hyphens` would be more precise, and less ambiguous for translators, as Claude summarises:

> English speakers can get away with “dashes” because English usage is loose here – but plenty of target languages distinguish these marks more rigidly than English does colloquially, or use entirely different words for a hyphen versus an en/em dash. A translator working purely from the English source, without checking the underlying code, could reasonably render “dashes” using their language’s word for a longer punctuation mark rather than the humble keyboard hyphen – producing a translated string that describes a character the validation doesn’t actually accept.

Also, this will align usage with the strings in the signup process, which refer to `hyphen`/`hyphens`:

https://github.com/bluesky-social/social-app/blob/b0a40145e9482ec0ba04a0786a9edd9cf61de04d/src/screens/Signup/StepHandle/index.tsx#L215

https://github.com/bluesky-social/social-app/blob/b0a40145e9482ec0ba04a0786a9edd9cf61de04d/src/screens/Signup/StepHandle/index.tsx#L220-L221

cc: jasonddtang