### PR TITLE
Fix support link cutoff in signup footer on mobile

### DIFF
--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -219,6 +219,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                       a.w_full,
                       a.py_lg,
                       a.flex_row,
+                      a.flex_wrap,
                       a.gap_md,
                       a.align_center,
                     ]}>
@@ -227,7 +228,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                       style={
                         gtMobile
                           ? [a.flex_1, a.flex, a.flex_row, a.justify_end]
-                          : []
+                          : [a.flex_shrink]
                       }>
                       <Text
                         style={[


### PR DESCRIPTION
> [!IMPORTANT]
> **Claude Code analyzed this issue and wrote the PR and the description.**
>
> **Although it passes CI, I have not tested the fix.**

## Context

In the Create account flow, the footer row holds the app-language selector on the left and a "Having trouble? Contact support" text on the right. On native and mobile web, for locales with long strings — or in English at larger text sizes — the support text overflows off the right edge of the screen and gets clipped.

| German – iOS – 100% | Spanish – iOS – 100% | 
|--------|--------|
| <img width="500" alt="IMG_7038" src="https://github.com/user-attachments/assets/021aafbe-db2d-40b8-9f39-1de083bc0405" /> | <img width="500" alt="IMG_7039" src="https://github.com/user-attachments/assets/cc4360f7-a492-4565-88a1-25e4a178cc9b" /> | 

| Aragonese – iOS – larger text | English – iOS – larger text |
|--------|--------|
| <img width="500" alt="IMG_7024" src="https://github.com/user-attachments/assets/292e41bd-2b31-4f12-ac9f-8acc1779f81c" /> | <img width="500" alt="IMG_7032" src="https://github.com/user-attachments/assets/fbc17a42-8611-4b0f-bc81-ea3cf85195dd" /> |

**Root cause** (`src/screens/Signup/index.tsx:217-247`): the footer is a `flex_row`, and on mobile (`!gtMobile`) the `View` wrapping the support text has **no flex styles at all** (`gtMobile ? [a.flex_1, ...] : []`). In Yoga, `flexShrink` defaults to `0`, so the text view renders at its intrinsic single-line width and simply overflows the row — the text never wraps because it never receives a width constraint.

**Desired behavior**: if the string can't fit beside the language selector, the whole text block wraps onto its own line underneath the selector.

## Change

Single file: `src/screens/Signup/index.tsx`

1. **Add `a.flex_wrap` to the footer row container** (the `View` at line 217 with `a.w_full, a.py_lg, a.flex_row, a.gap_md, a.align_center`).
   - Yoga places flex items on lines using their intrinsic (flex-basis) size before shrinking, so when the text block doesn't fit next to the dropdown, it wraps to a second line below it.
   - The existing `a.gap_md` applies to both axes in Yoga, so wrapped lines get sensible vertical spacing for free.
   - On `gtMobile` this is a no-op: the text wrapper there uses `a.flex_1` (flex-basis 0), which always fits on the first line, so desktop layout is unchanged.

2. **Give the mobile text wrapper `a.flex_shrink`** — change the ternary at line 226-231 from `gtMobile ? [a.flex_1, a.flex, a.flex_row, a.justify_end] : []` to use `[a.flex_shrink]` for the mobile branch.
   - This handles the extreme case where the string is longer than the *full* row width even on its own line (very long locales and/or large font scale): shrinking constrains the view's width, letting the `Text` wrap internally onto multiple lines instead of clipping.
   - Shrink only kicks in within a line after wrapping, so it doesn't prevent the wrap-below-the-selector behavior from step 1.

No other screens share this pattern — the language-dropdown + support-link footer exists only in the Signup screen (`AppLanguageDropdown` is used elsewhere, but not in this row layout).