### PR TITLE
Fix KWS language picker silently resetting Arabic, Chinese, Filipino & Portuguese to English

### DIFF
--- a/src/components/LanguageSelect.tsx
+++ b/src/components/LanguageSelect.tsx
@@ -1,8 +1,6 @@
-import {useCallback} from 'react'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
-import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {APP_LANGUAGES} from '#/locale/languages'
 import * as Select from '#/components/Select'
 
@@ -22,18 +20,13 @@ export function LanguageSelect({
 }) {
   const {_} = useLingui()
 
-  const handleOnChange = useCallback(
-    (value: string) => {
-      if (!value) return
-      onChange(sanitizeAppLanguageSetting(value))
-    },
-    [onChange],
-  )
+  const handleOnChange = (value: string) => {
+    if (!value) return
+    onChange(value)
+  }
 
   return (
-    <Select.Root
-      value={value ? sanitizeAppLanguageSetting(value) : undefined}
-      onValueChange={handleOnChange}>
+    <Select.Root value={value} onValueChange={handleOnChange}>
       <Select.Trigger label={_(msg`Select language`)}>
         <Select.ValueText placeholder={_(msg`Select language`)} />
         <Select.Icon />


### PR DESCRIPTION
## Context

In the KWS age assurance init dialog, selecting Arabic (`ar`), Chinese Simplified (`zh-Hans`), Filipino (`tl`), or Portuguese (`pt`) in the "Preferred language" dropdown snaps back to English. These KWS language codes don't map to Bluesky app languages.

**Root cause** — `src/components/LanguageSelect.tsx` unconditionally pipes both the displayed value and the selected value through `sanitizeAppLanguageSetting()` (`src/locale/helpers.ts:159`):

```tsx
const handleOnChange = useCallback((value: string) => {
  if (!value) return
  onChange(sanitizeAppLanguageSetting(value))  // 'ar' -> 'en'
}, [onChange])
...
<Select.Root value={value ? sanitizeAppLanguageSetting(value) : undefined} ...>
```

`sanitizeAppLanguageSetting` coerces any code that isn't a Bluesky `AppLanguage` to `AppLanguage.en`. The KWS list (`KWS_SUPPORTED_LANGS` in `src/components/ageAssurance/const.ts`) contains four values with no `AppLanguage` equivalent:

| KWS value | Language | AppLanguage equivalent |
|---|---|---|
| `ar` | Arabic | none |
| `zh-Hans` | Chinese Simplified | none (app uses `zh-Hans-CN`) |
| `tl` | Filipino | none |
| `pt` | Portuguese | none (app has only `pt-BR` / `pt-PT`) |

So picking any of them sanitizes to `'en'` in `onChange`, and the dialog state + displayed selection revert to English. All other KWS values happen to match an `AppLanguage` exactly, which is why only these four are broken. (A related symptom: Chinese app-language users get `'zh-Hans'` preselected via `convertToKWSSupportedLanguage`, but the dropdown *displays* English because the `value` prop is sanitized too.)

The sanitization does not belong in the generic `LanguageSelect` component: its `items` are caller-supplied and need not be app languages. `AgeAssuranceInitDialog` is the **only** consumer of `#/components/LanguageSelect` (verified by grep), and the underlying `Select` component matches/emits raw item values, so removing the sanitization is safe. The KWS flow language is independent of the app UI language and the option labels are already hardcoded native names.

## Change

**File: `src/components/LanguageSelect.tsx`**

1. Remove the `sanitizeAppLanguageSetting` calls (and its now-unused import):
   - `handleOnChange` passes the raw selected value to `onChange` (keep the `if (!value) return` guard).
   - `Select.Root` receives `value` as-is. If a value doesn't match any item, `Select.Content` already falls back to showing the placeholder, so no extra guard is needed.
2. While here, drop the `useCallback` wrapper per repo convention (React Compiler is enabled), turning `handleOnChange` into a plain function.

Resulting behavior:
- Selecting العربية / 简体中文 / Filipino / Português keeps the selection and submits `ar` / `zh-Hans` / `tl` / `pt` to `app.bsky.ageassurance.begin`.
- The default-items path (`APP_LANGUAGES`) is unaffected: its item values are already canonical `AppLanguage` codes, and the existing sole caller passes values produced by `convertToKWSSupportedLanguage` (already KWS codes).

No changes needed in `AgeAssuranceInitDialog.tsx` — its `convertToKWSSupportedLanguage` mapping is correct once `LanguageSelect` stops mangling values.