### PR TITLE
Localize feed display names dynamically

### DIFF
--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -9,6 +9,7 @@ import {
   RichText,
 } from '@atproto/api'
 import {t} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react/macro'
 import {
   type InfiniteData,
   keepPreviousData,
@@ -443,6 +444,7 @@ const createPinnedFeedInfosQueryKey = (
   )
 
 export function usePinnedFeedsInfos() {
+  const {t: l} = useLingui()
   const {hasSession} = useSession()
   const agent = useAgent()
   const {data: preferences, isLoading: isLoadingPrefs} = usePreferencesQuery()
@@ -530,6 +532,30 @@ export function usePinnedFeedsInfos() {
       }
       return result
     },
+    /*
+     * The cached data keeps the canonical English display names. Localizing
+     * them here keeps the persisted cache language-neutral and re-applies the
+     * translation when the app language changes, without a refetch.
+     */
+    select: useCallback(
+      (data: SavedFeedSourceInfo[]): SavedFeedSourceInfo[] =>
+        data.map(feed => {
+          if (feed.feedDescriptor === 'following') {
+            return {
+              ...feed,
+              displayName: l({message: 'Following', context: 'feed-name'}),
+            }
+          }
+          if (feed.savedFeed.id === PWI_DISCOVER_FEED_STUB.savedFeed.id) {
+            return {
+              ...feed,
+              displayName: l({message: 'Discover', context: 'feed-name'}),
+            }
+          }
+          return feed
+        }),
+      [l],
+    ),
   })
 }
 

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -546,7 +546,12 @@ export function usePinnedFeedsInfos() {
               displayName: l({message: 'Following', context: 'feed-name'}),
             }
           }
-          if (feed.savedFeed.id === PWI_DISCOVER_FEED_STUB.savedFeed.id) {
+          /*
+           * Intentionally overrides the server-provided name of the official
+           * Discover feed (and the logged-out stub, which shares this URI),
+           * since feedgen records cannot provide localized names.
+           */
+          if (feed.uri === DISCOVER_FEED_URI) {
             return {
               ...feed,
               displayName: l({message: 'Discover', context: 'feed-name'}),

--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo} from 'react'
+import {useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 
 import {type NavigationProp} from '#/lib/routes/types'
@@ -16,6 +17,7 @@ export function HomeHeader(
   },
 ) {
   const {feeds, onSelect: onSelectProp} = props
+  const {t: l} = useLingui()
   const {hasSession} = useSession()
   const navigation = useNavigation<NavigationProp>()
 
@@ -30,10 +32,16 @@ export function HomeHeader(
   const items = useMemo(() => {
     const pinnedNames = feeds.map(f => f.displayName)
     if (!hasPinnedCustom) {
-      return pinnedNames.concat('Feeds ✨')
+      return pinnedNames.concat(
+        l({
+          message: 'Feeds ✨',
+          comment:
+            'Last tab on the home screen when the user has no pinned custom feeds; links to the Feeds screen',
+        }),
+      )
     }
     return pinnedNames
-  }, [hasPinnedCustom, feeds])
+  }, [hasPinnedCustom, feeds, l])
 
   const onPressFeedsLink = useCallback(() => {
     navigation.navigate('Feeds')

--- a/src/view/com/posts/DiscoverFallbackHeader.tsx
+++ b/src/view/com/posts/DiscoverFallbackHeader.tsx
@@ -1,5 +1,5 @@
 import {View} from 'react-native'
-import {Trans} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {InfoCircleIcon} from '#/lib/icons'
@@ -7,6 +7,7 @@ import {TextLink} from '../util/Link'
 import {Text} from '../util/text/Text'
 
 export function DiscoverFallbackHeader() {
+  const {t: l} = useLingui()
   const pal = usePalette('default')
   return (
     <View
@@ -31,7 +32,7 @@ export function DiscoverFallbackHeader() {
             <TextLink
               type="md-medium"
               href="/profile/bsky.app/feed/whats-hot"
-              text="Discover"
+              text={l({message: 'Discover', context: 'feed-name'})}
               style={pal.link}
             />
             .

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react'
 import {ActivityIndicator, StyleSheet} from 'react-native'
 import {withSpring} from 'react-native-reanimated'
-import {useLingui} from '@lingui/react/macro'
 import {useFocusEffect} from '@react-navigation/native'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
@@ -113,7 +112,6 @@ function HomeScreenReady({
   pinnedFeedInfos: SavedFeedSourceInfo[]
 }) {
   const ax = useAnalytics()
-  const {t: l} = useLingui()
   const allFeeds = useMemo(
     () => pinnedFeedInfos.map(f => f.feedDescriptor),
     [pinnedFeedInfos],
@@ -218,10 +216,7 @@ function HomeScreenReady({
             testID="homeScreenFeedTabs"
             onPressSelected={onPressSelected}
             // @ts-ignore
-            feeds={[
-              {displayName: l({message: 'Following', context: 'feed-name'})},
-              {displayName: l({message: 'Discover', context: 'feed-name'})},
-            ]}
+            feeds={[{displayName: 'Following'}, {displayName: 'Discover'}]}
           />
         )
       }
@@ -235,7 +230,7 @@ function HomeScreenReady({
         />
       )
     },
-    [onPressSelected, pinnedFeedInfos, demoMode, l],
+    [onPressSelected, pinnedFeedInfos, demoMode],
   )
 
   const renderFollowingEmptyState = useCallback(() => {

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react'
 import {ActivityIndicator, StyleSheet} from 'react-native'
 import {withSpring} from 'react-native-reanimated'
+import {useLingui} from '@lingui/react/macro'
 import {useFocusEffect} from '@react-navigation/native'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
@@ -112,6 +113,7 @@ function HomeScreenReady({
   pinnedFeedInfos: SavedFeedSourceInfo[]
 }) {
   const ax = useAnalytics()
+  const {t: l} = useLingui()
   const allFeeds = useMemo(
     () => pinnedFeedInfos.map(f => f.feedDescriptor),
     [pinnedFeedInfos],
@@ -216,7 +218,10 @@ function HomeScreenReady({
             testID="homeScreenFeedTabs"
             onPressSelected={onPressSelected}
             // @ts-ignore
-            feeds={[{displayName: 'Following'}, {displayName: 'Discover'}]}
+            feeds={[
+              {displayName: l({message: 'Following', context: 'feed-name'})},
+              {displayName: l({message: 'Discover', context: 'feed-name'})},
+            ]}
           />
         )
       }
@@ -230,7 +235,7 @@ function HomeScreenReady({
         />
       )
     },
-    [onPressSelected, pinnedFeedInfos, demoMode],
+    [onPressSelected, pinnedFeedInfos, demoMode, l],
   )
 
   const renderFollowingEmptyState = useCallback(() => {


### PR DESCRIPTION
## Summary

This PR makes the hardcoded English feed/tab names — "Following", "Discover", and "Feeds ✨" — translatable via Lingui. Translations are applied at the query-result/presentation layer, so labels update immediately when the app language changes, without a refetch and without baking a language into the persisted cache.

## Changes

- **src/state/queries/feed.ts**: Added a `select` callback to `usePinnedFeedsInfos()` that localizes the "Following" timeline name and the "Discover" feed name. "Discover" is matched by `DISCOVER_FEED_URI`, which covers both the logged-out stub and the official Discover feed for signed-in users – this intentionally overrides the server-provided record name, since `app.bsky.feed.generator` records have a single `displayName` with no localization mechanism. This one change covers every consumer of these names: the home tab bar, the document title (`useSetTitle`), and the desktop left nav (including its accessibility label/hint).

- **src/view/com/home/HomeHeader.tsx**: Localized the "Feeds ✨" tab label (shown when no custom feeds are pinned), keeping the sparkle inside the message so translators control its placement, with a comment describing where the label appears.

- **src/view/com/posts/DiscoverFallbackHeader.tsx**: Localized the "Discover" link text. As a component prop inside `<Trans>`, it was not extracted by Lingui, so it stayed English even though the surrounding sentence was translated. The sentence's existing msgid is unchanged.

## Implementation Details

- The `select` callback keeps the TanStack Query cache language-neutral: this query is persisted to disk (`persistedVersion: 1`) with a long cache life, and locale switches don't invalidate react-query caches, so translating inside the `queryFn` would have left stale-language labels after a language switch (and restored them in the wrong language on cold start). `select` is memoized with `useCallback([l])`, so it re-runs exactly when the locale changes.
- "Following" and "Discover" reuse the existing `feed-name` message context (already used by `Feeds.tsx` and `SavedFeeds.tsx`), so "Following" adds no new msgid. The new msgids ("Discover" with `feed-name` context, and "Feeds ✨") will be picked up by the nightly `intl:extract` CI job – no `.po` files are touched here.
- The demo-mode tab labels in `src/view/screens/Home.tsx` are deliberately left hardcoded: demo mode is not an end-user feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SYAbovxvyYYrEDat7jwMh