### PR TITLE
Use Spanish for Aragonese `intl-displaynames`

### DIFF
--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -69,7 +69,7 @@ export async function dynamicActivate(locale: AppLanguage) {
         import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/an.js'),
         import('@formatjs/intl-numberformat/locale-data/an.js'),
-        import('@formatjs/intl-displaynames/locale-data/an.js'),
+        import('@formatjs/intl-displaynames/locale-data/es.js'),
       ])
       return dateLocale
     }

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -69,6 +69,8 @@ export async function dynamicActivate(locale: AppLanguage) {
         import('date-fns/locale/es').then(m => m.es),
         import('@formatjs/intl-pluralrules/locale-data/an.js'),
         import('@formatjs/intl-numberformat/locale-data/an.js'),
+        // Aragonese locale data is missing
+        // see: https://github.com/bluesky-social/social-app/pull/11327
         import('@formatjs/intl-displaynames/locale-data/es.js'),
       ])
       return dateLocale


### PR DESCRIPTION
> [!IMPORTANT]
> This fix seems logical to me, but I haven't tested it.

[It has been highlighted](https://github.com) that what seems to be a similar issue to the one that was fixed in 9574 for Esperanto is now occurring with Aragonese – in the `intl-displaynames` [package](https://npmx.dev/package-code/@formatjs/intl-displaynames/v/7.3.9/locale-data/an.js) there isn't actually any data in the `locale-data/an.js` file:

<img width="2250" height="1206" alt="IMG_0313" src="https://github.com/user-attachments/assets/f9c09642-f769-452d-93dc-5bbef045d577" />

So when the app tries to load the polyfill's locale data for Aragonese, it crashes:

<img width="1206" height="735" alt="IMG_0312" src="https://github.com/user-attachments/assets/eb2e68a0-076a-472f-8c8e-cbee7b6d594b" />

However, in this case, the data seems to be missing because the [CLDR data for language names](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/an/languages.json) is almost entirely absent, with only an entry for `an` itself in Aragonese.

Therefore, this PR proposes using the Spanish `intl-displaynames` data for Aragonese, similar to what we do for `date-fns`.

Note: I checked each one of our other app languages, and only Aragonese is affected by this.
___

## Test Plan

1. On native, open [Settings > Languages](https://bsky.app/settings/language) and change the **App language** to **Aragonese**
2. Force-quit and restart the app
3. Open [Settings > Languages](https://bsky.app/settings/language) – the app should not crash and language names should be displayed in Spanish