### PR TITLE
Fix language names not updating when the app language changes

### DIFF
--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -33,16 +33,36 @@ export function code3ToCode2Strict(lang: string): string | undefined {
 }
 
 const displayNamesCache = new Map<string, Intl.DisplayNames>()
+const regionNamesCache = new Map<string, Intl.DisplayNames>()
+
+/**
+ * Drops every memoized `Intl.DisplayNames` instance. Call this whenever new Intl locale data is
+ * registered.
+ *
+ * On native, `Intl.DisplayNames` is polyfilled and its locale data is imported asynchronously on
+ * app language change. The polyfill resolves the locale eagerly in the constructor, so an instance
+ * built before that data lands silently falls back to English and would otherwise stay cached for
+ * the rest of the session.
+ */
+export function resetDisplayNamesCaches() {
+  displayNamesCache.clear()
+  regionNamesCache.clear()
+}
 
 function getDisplayNames(appLang: string): Intl.DisplayNames {
-  let cached = displayNamesCache.get(appLang)
+  /*
+   * Key on the sanitized language so the cache lines up with the locale we actually loaded Intl
+   * data for - callers pass the raw `appLanguage` pref, which may still hold a legacy value.
+   */
+  const locale = sanitizeAppLanguageSetting(appLang)
+  let cached = displayNamesCache.get(locale)
   if (!cached) {
-    cached = new Intl.DisplayNames([appLang], {
+    cached = new Intl.DisplayNames([locale], {
       type: 'language',
       fallback: 'none',
       languageDisplay: 'standard',
     })
-    displayNamesCache.set(appLang, cached)
+    displayNamesCache.set(locale, cached)
   }
   return cached
 }
@@ -315,16 +335,16 @@ export function regionName(countryCode: string, appLang: string): string {
   return countryCode
 }
 
-const regionNamesCache = new Map<string, Intl.DisplayNames>()
-
 function getRegionNames(appLang: string): Intl.DisplayNames {
-  let cached = regionNamesCache.get(appLang)
+  // See the note on cache keys in `getDisplayNames`
+  const locale = sanitizeAppLanguageSetting(appLang)
+  let cached = regionNamesCache.get(locale)
   if (!cached) {
-    cached = new Intl.DisplayNames([appLang], {
+    cached = new Intl.DisplayNames([locale], {
       type: 'region',
       fallback: 'none',
     })
-    regionNamesCache.set(appLang, cached)
+    regionNamesCache.set(locale, cached)
   }
   return cached
 }

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -486,8 +486,16 @@ export function useLocaleLanguage() {
 
   useEffect(() => {
     const locale = sanitizeAppLanguageSetting(appLanguage)
+    let cancelled = false
 
     void dynamicActivate(locale).then(nextDateLocale => {
+      /*
+       * A newer app language was picked while this one's Intl data was still loading, so this
+       * result is stale. Each locale awaits a different set of imports, so an earlier request can
+       * resolve last and would otherwise clobber the current language for good.
+       */
+      if (cancelled) return
+
       /*
        * `dynamicActivate` activates the message catalog before awaiting the Intl locale data, so
        * anything rendered in between built its `Intl.DisplayNames` against the fallback locale.
@@ -498,6 +506,10 @@ export function useLocaleLanguage() {
       i18n.activate(locale)
       setDateLocale(nextDateLocale ?? defaultLocale)
     })
+
+    return () => {
+      cancelled = true
+    }
   }, [appLanguage])
 
   return dateLocale

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -12,7 +12,10 @@ import {useEffect, useState} from 'react'
 import {i18n} from '@lingui/core'
 import {enUS as defaultLocale} from 'date-fns/locale/en-US'
 
-import {sanitizeAppLanguageSetting} from '#/locale/helpers'
+import {
+  resetDisplayNamesCaches,
+  sanitizeAppLanguageSetting,
+} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
 import {messages as messagesAn} from '#/locale/locales/an/messages'
 import {messages as messagesAst} from '#/locale/locales/ast/messages'
@@ -482,11 +485,19 @@ export function useLocaleLanguage() {
   const [dateLocale, setDateLocale] = useState(defaultLocale)
 
   useEffect(() => {
-    void dynamicActivate(sanitizeAppLanguageSetting(appLanguage)).then(
-      locale => {
-        setDateLocale(locale ?? defaultLocale)
-      },
-    )
+    const locale = sanitizeAppLanguageSetting(appLanguage)
+
+    void dynamicActivate(locale).then(nextDateLocale => {
+      /*
+       * `dynamicActivate` activates the message catalog before awaiting the Intl locale data, so
+       * anything rendered in between built its `Intl.DisplayNames` against the fallback locale.
+       * Now that the data is registered, drop those instances and re-activate to emit a lingui
+       * change event, which re-renders every `Trans`/`useLingui` consumer with real display names.
+       */
+      resetDisplayNamesCaches()
+      i18n.activate(locale)
+      setDateLocale(nextDateLocale ?? defaultLocale)
+    })
   }, [appLanguage])
 
   return dateLocale

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -3,7 +3,10 @@ import {i18n, type Messages} from '@lingui/core'
 import {type Locale} from 'date-fns/locale'
 import {enUS as defaultLocale} from 'date-fns/locale/en-US'
 
-import {sanitizeAppLanguageSetting} from '#/locale/helpers'
+import {
+  resetDisplayNamesCaches,
+  sanitizeAppLanguageSetting,
+} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
 import {useLanguagePrefs} from '#/state/preferences'
 
@@ -314,6 +317,7 @@ export function useLocaleLanguage() {
 
     document.documentElement.lang = sanitizedLanguage
     void dynamicActivate(sanitizedLanguage).then(locale => {
+      resetDisplayNamesCaches()
       setDateLocale(locale)
     })
   }, [appLanguage])

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -11,7 +11,10 @@ import {AppLanguage} from '#/locale/languages'
 import {useLanguagePrefs} from '#/state/preferences'
 
 /**
- * We do a dynamic import of just the catalog that we need
+ * We do a dynamic import of just the catalog that we need.
+ *
+ * Despite the name this only loads - the caller activates, so that a catalog superseded while it
+ * was still downloading can be discarded instead of clobbering the current language.
  */
 export async function dynamicActivate(locale: AppLanguage) {
   let messages: Messages
@@ -302,10 +305,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
   }
 
-  i18n.load(locale, messages)
-  i18n.activate(locale)
-
-  return dateLocale
+  return {messages, dateLocale}
 }
 
 export function useLocaleLanguage() {
@@ -313,13 +313,27 @@ export function useLocaleLanguage() {
   const [dateLocale, setDateLocale] = useState(defaultLocale)
 
   useEffect(() => {
-    const sanitizedLanguage = sanitizeAppLanguageSetting(appLanguage)
+    const locale = sanitizeAppLanguageSetting(appLanguage)
+    let cancelled = false
 
-    document.documentElement.lang = sanitizedLanguage
-    void dynamicActivate(sanitizedLanguage).then(locale => {
+    void dynamicActivate(locale).then(({messages, dateLocale: nextDateLocale}) => {
+      /*
+       * A newer app language was picked while this catalog was still downloading, so this result
+       * is stale. Activating happens here rather than inside `dynamicActivate` so that everything
+       * reflecting the active language is applied together, under this guard.
+       */
+      if (cancelled) return
+
+      i18n.load(locale, messages)
+      i18n.activate(locale)
+      document.documentElement.lang = locale
       resetDisplayNamesCaches()
-      setDateLocale(locale)
+      setDateLocale(nextDateLocale)
     })
+
+    return () => {
+      cancelled = true
+    }
   }, [appLanguage])
 
   return dateLocale


### PR DESCRIPTION
## Problem

In **Settings > Languages**, changing the **App language** translates the UI immediately, but the **Primary language** and **Content languages** values keep showing language names in the *previous* language. They stay wrong until the app is restarted.

For example, switching to Welsh translates the headings (`Iaith Ap`, `Prif iaith`), but the Primary language value still reads "English" instead of "Saesneg".

This affects native only. Web is unaffected, since it uses the browser's built-in ICU data rather than a polyfill.

## Root cause

Three things combine:

**1. The polyfill data arrives asynchronously.** On native, `Intl.DisplayNames` is force-polyfilled in `src/locale/i18n.ts` with only `en` locale data registered statically. Every other locale is loaded with `await import('@formatjs/intl-displaynames/locale-data/<x>.js')` inside `dynamicActivate`.

**2. A stale instance gets cached forever.** Selecting a language calls `setAppLanguage`, which updates the `languagePrefs` context. `LanguageSettingsScreen` consumes `useLanguagePrefs()`, so it re-renders *synchronously* with the new language — before the effect that loads the locale data has even run. That render calls `languageName(...)`, which constructs `new Intl.DisplayNames(['cy'], …)`. The polyfill resolves the locale eagerly in the constructor, finds no `cy` data, and silently falls back to `en`. `displayNamesCache` then stores that English-resolved instance under key `'cy'` and never invalidates it.

**3. Nothing re-renders once the data does land.** `dynamicActivate` calls `i18n.loadAndActivate` *before* its `await`, so lingui's re-render also fires too early. The only post-await state update is `setDateLocale`, which feeds `DateLocaleContext` — a context the settings screen does not consume, and whose identity doesn't even change for some languages (`ga`, `ia`, `ne`, `an`, `ast`).

Restarting the app appears to fix it only because the locale data is registered before the screen is first rendered.

## Changes

**`src/locale/helpers.ts`**
- Add an exported `resetDisplayNamesCaches()` that clears the memoized `Intl.DisplayNames` instances. `regionNamesCache` has the identical lifetime bug (affecting `regionName()`, used by the phone-code select and age assurance), so it is cleared alongside `displayNamesCache`. Its declaration moves up next to `displayNamesCache` so the two caches and their reset sit together.
- Key both caches on `sanitizeAppLanguageSetting(appLang)`. Callers pass the raw `appLanguage` pref, which may still hold a legacy comma-separated value, while `dynamicActivate` receives the sanitized one — so the cache key could disagree with the locale data was actually loaded for.

**`src/locale/i18n.ts`** (native)
- In `useLocaleLanguage`, once `dynamicActivate` resolves, clear the caches and then call `i18n.activate(locale)`. The re-activation emits a lingui change event, which re-renders every `Trans` / `useLingui` consumer — fixing all eight language-name call sites (`LanguageSettings`, `LanguageSelectDialog`, `Post/Translated`, `PostLanguageSelect`, `SuggestedLanguage`, `SearchLanguageDropdown`, `DetectedLanguagesAdmonition`, `lib/translation`) without touching any of them.

**`src/locale/i18n.web.ts`**
- Clear the caches on the same schedule, to keep the sanitized cache keys consistent across platforms. No re-activation is added here: web's `dynamicActivate` already loads and activates *after* its awaits, and the browser always has the display-name data available.

## Verification

The diagnosis and the fix were confirmed against the real formatjs polyfill — building an instance before the `cy` data lands, then after, then after clearing the cache:

```
before data  resolved=en  of("en")=English
after  data  (cached)   of("en")=English   <- the bug
after  clear resolved=cy  of("en")=Saesneg <- the fix
```

The mechanism the fix relies on was verified against lingui 5.9.5 sources: `I18n.activate()` unconditionally calls `emit("change")`, and `@lingui/react`'s provider responds by building a **new** context object, so consumers genuinely re-render.

### Manual testing

1. Settings > Languages, set **App language** to `Cymraeg – Welsh`. The **Primary language** value should change from "English" to "Saesneg" without leaving the screen, and its picker list should be in Welsh.
2. Switch back to `British English`; the value should return to "English" immediately.
3. Check a language with no `date-fns` locale (`ga`, `ia`, `ne`) — these previously had no post-await re-render at all, so they are the strictest cases.
4. Open the phone-code select under a non-English app language; country names should be localized on first open after a language switch.
5. Confirm web still updates language names instantly.

https://claude.ai/code/session_01E12LDyPgjy3h13eiMj7uta