### PR TITLE
Tweak strings

### DIFF
--- a/src/components/moderation/ReportDialog/index.tsx
+++ b/src/components/moderation/ReportDialog/index.tsx
@@ -268,7 +268,7 @@ function Inner(props: ReportDialogProps) {
 
       let error = l`Something went wrong. Please try again.`
       if (classification.kind === 'account-takedown') {
-        error = l`Your account cannot submit reports while it is taken down.`
+        error = l`Your account cannot submit reports while it is suspended.`
       } else if (classification.kind === 'invalid-reason-type') {
         error = l`This moderation service does not support that report reason. Please choose a different reason or moderation service.`
       } else if (classification.kind === 'service-unavailable') {

--- a/src/view/com/composer/state/video.ts
+++ b/src/view/com/composer/state/video.ts
@@ -446,11 +446,11 @@ function getProcessingErrorMessage(
       return i18n._(msg`The selected video could not be encoded.`)
     case 'pds_upload_failure':
       return i18n._(
-        msg`The video could not be uploaded to your PDS. Please try again.`,
+        msg`The video could not be uploaded to your hosting provider. Please try again.`,
       )
     case 'pds_upload_unsupported_blob_size':
       return i18n._(
-        msg`Your PDS does not support videos this large. Please try again with a smaller file.`,
+        msg`Your hosting provider does not support videos this large. Please try again with a smaller file.`,
       )
     case 'generic_failure':
     default:


### PR DESCRIPTION
In response to a [discussion on the Bluesky Translators Discord](https://discord.com/channels/1338165055992107061/1338165056596082731/1534246748170747935), this PR proposes tweaking a string that refers to an account being `taken down` to instead refer to an account being `suspended`.

`suspended`/`suspension` is used in 8 existing strings, while this was the first usage of `taken down`, so `suspended` will probably be the term that is more familiar and easier for users to understand.

In a similar vein, and also following a [suggestion on the Bluesky Translators Discord](https://discord.com/channels/1338165055992107061/1338165056596082731/1534791667566252053), this PR also proposes using `hosting provider` instead of `PDS` in two error strings. `Hosting provider` is used in 14 existing strings, while `PDS` is used in only 1, so `hosting provider` is likely to be more familiar and easily understood.

| `suspended`/`suspension` usages| `hosting provider` usages |
|--------|--------|
| <img width="341" height="1025" alt="IMG_3201" src="https://github.com/user-attachments/assets/0027fce7-42e8-47d4-bcae-a0e8dacaae75" /> | <img width="338" height="1042" alt="IMG_3202" src="https://github.com/user-attachments/assets/d04a3ae9-33f7-4a20-b0ed-66f5719836d2" /> | 