### PR TITLE
Add “Hide reposts from {user}” option to the post context menu

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -1060,6 +1060,18 @@ export type Events = {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
     feedDescriptor?: string
   }
+  'postMenu:muteReposts': {
+    uri: string
+    reposterDid: string
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
+    feedDescriptor?: string
+  }
+  'postMenu:unmuteReposts': {
+    uri: string
+    reposterDid: string
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
+    feedDescriptor?: string
+  }
   'postMenu:reportPost': {
     uri: string
     authorDid: string

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -198,11 +198,12 @@ export function Item({
   )
 }
 
-export function ItemText({children, style}: ItemTextProps) {
+export function ItemText({children, style, emoji}: ItemTextProps) {
   const t = useTheme()
   const {disabled, destructive} = useMenuItemContext()
   return (
     <Text
+      emoji={emoji}
       numberOfLines={1}
       ellipsizeMode="middle"
       style={[

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -301,15 +301,27 @@ export function Item({
   )
 }
 
-export function ItemText({children, style}: ItemTextProps) {
+export function ItemText({children, style, emoji}: ItemTextProps) {
   const t = useTheme()
   const {disabled, destructive} = useMenuItemContext()
   return (
     <Text
+      emoji={emoji}
+      numberOfLines={2}
       style={[
         a.flex_1,
         a.font_semi_bold,
         t.atoms.text_contrast_high,
+        /*
+         * The dropdown is width-capped to the viewport (see
+         * dropdown-menu-constrain-size), so unbreakable tokens of user text
+         * (hashtags, handles, display names) must break mid-token rather
+         * than force a horizontal overflow at the cap.
+         */
+        web({
+          overflowWrap: 'break-word',
+          wordBreak: 'break-word',
+        }),
         style,
         destructive && {color: t.palette.negative_500},
         disabled && t.atoms.text_contrast_low,

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -104,7 +104,15 @@ export type ItemProps = React.PropsWithChildren<
     }
 >
 
-export type ItemTextProps = React.PropsWithChildren<TextStyleProp & {}>
+export type ItemTextProps = React.PropsWithChildren<
+  TextStyleProp & {
+    /**
+     * Forwarded to the underlying `Text`. Enable when children may contain
+     * emoji, e.g. user-generated text such as display names.
+     */
+    emoji?: boolean
+  }
+>
 export type ItemIconProps = React.PropsWithChildren<{
   icon: React.ComponentType<SVGIconProps>
   position?: 'left' | 'right'

--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import {
+  type AppBskyActorDefs,
   type AppBskyFeedDefs,
   type AppBskyFeedPost,
   type AppBskyFeedThreadgate,
@@ -14,11 +15,12 @@ import {
   type RichText as RichTextAPI,
 } from '@atproto/api'
 import {plural} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 
 import {DISCOVER_DEBUG_DIDS} from '#/lib/constants'
 import {useOpenLink} from '#/lib/hooks/useOpenLink'
+import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {getCurrentRoute} from '#/lib/routes/helpers'
 import {makeProfileLink} from '#/lib/routes/links'
 import {
@@ -31,7 +33,11 @@ import {useTranslate} from '#/lib/translation'
 import {getPostLanguageTags} from '#/locale/helpers'
 import {logger} from '#/logger'
 import {type Shadow} from '#/state/cache/post-shadow'
-import {useProfileShadow} from '#/state/cache/profile-shadow'
+import {
+  getProfileShadow,
+  useMaybeProfileShadow,
+  useProfileShadow,
+} from '#/state/cache/profile-shadow'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {
   useHiddenPosts,
@@ -48,6 +54,7 @@ import {getMaybeDetachedQuoteEmbed} from '#/state/queries/postgate/util'
 import {
   useProfileBlockMutationQueue,
   useProfileMuteMutationQueue,
+  useProfileMuteRepostsMutationQueue,
 } from '#/state/queries/profile'
 import {
   InvalidInteractionSettingsError,
@@ -79,6 +86,7 @@ import {
 } from '#/components/icons/Mute'
 import {PersonX_Stroke2_Corner0_Rounded as PersonX} from '#/components/icons/Person'
 import {Pin_Stroke2_Corner0_Rounded as PinIcon} from '#/components/icons/Pin'
+import {RepostStrike_Stroke2_Corner0_Rounded as RepostStrikeIcon} from '#/components/icons/Repost'
 import {SettingsGear2_Stroke2_Corner0_Rounded as Gear} from '#/components/icons/SettingsGear2'
 import {
   SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute,
@@ -106,6 +114,7 @@ let PostMenuItems = ({
   richText,
   threadgateRecord,
   onShowLess,
+  reposter,
   logContext,
   forceGoogleTranslate,
 }: {
@@ -121,6 +130,7 @@ let PostMenuItems = ({
   timestamp: string
   threadgateRecord?: AppBskyFeedThreadgate.Record
   onShowLess?: (interaction: AppBskyFeedDefs.Interaction) => void
+  reposter?: AppBskyActorDefs.ProfileViewBasic
   logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
   forceGoogleTranslate: boolean
 }): React.ReactNode => {
@@ -155,6 +165,22 @@ let PostMenuItems = ({
   const postUri = post.uri
   const postCid = post.cid
   const postAuthor = useProfileShadow(post.author)
+  const reposterShadow = useMaybeProfileShadow(reposter)
+  const [queueMuteReposts, queueUnmuteReposts] =
+    useProfileMuteRepostsMutationQueue(
+      // the fallback is never acted on: the menu item only renders when reposterShadow exists
+      reposterShadow ?? postAuthor,
+    )
+  const reposterName = reposterShadow
+    ? createSanitizedDisplayName(reposterShadow, true)
+    : ''
+  const canHideReposter =
+    !!reposterShadow &&
+    reposterShadow.did !== currentAccount?.did &&
+    !reposterShadow.viewer?.muted &&
+    !reposterShadow.viewer?.mutedOnlyReposts &&
+    !reposterShadow.viewer?.blocking &&
+    !reposterShadow.viewer?.mutedByList
   const quoteEmbed = useMemo(() => {
     if (!currentAccount || !post.embed) return
     return getMaybeDetachedQuoteEmbed({
@@ -487,6 +513,77 @@ let PostMenuItems = ({
     }
   }
 
+  const onUndoHideReposts = async () => {
+    if (!reposterShadow) return
+    try {
+      /*
+       * The account may have been fully muted while the toast was up. The
+       * generic unmute would clear that mute too, so undo nothing - the
+       * reposts stay hidden by the stronger full mute.
+       */
+      if (reposter && getProfileShadow(reposter)?.muted) return
+      await queueUnmuteReposts()
+      Toast.show(
+        <Toast.Outer>
+          <Toast.Icon />
+          <Toast.Text emoji>
+            {l`Reposts from ${reposterName} will be shown in feeds`}
+          </Toast.Text>
+        </Toast.Outer>,
+      )
+    } catch (err) {
+      const e = err as Error
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to unhide reposts', {message: e})
+        Toast.show(l`There was an issue! ${e.toString()}`, {
+          type: 'error',
+        })
+      }
+    } finally {
+      ax.metric('postMenu:unmuteReposts', {
+        uri: postUri,
+        reposterDid: reposterShadow.did,
+        logContext,
+        feedDescriptor: feedFeedback.feedDescriptor,
+      })
+    }
+  }
+
+  const onHideReposts = async () => {
+    if (!reposterShadow) return
+    try {
+      await queueMuteReposts()
+      Toast.show(
+        <Toast.Outer>
+          <Toast.Icon />
+          <Toast.Text emoji>
+            {l`Reposts from ${reposterName} will be hidden in feeds`}
+          </Toast.Text>
+          <Toast.Action
+            label={l`Undo`}
+            onPress={() => void onUndoHideReposts()}>
+            <Trans>Undo</Trans>
+          </Toast.Action>
+        </Toast.Outer>,
+      )
+    } catch (err) {
+      const e = err as Error
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to hide reposts', {message: e})
+        Toast.show(l`There was an issue! ${e.toString()}`, {
+          type: 'error',
+        })
+      }
+    } finally {
+      ax.metric('postMenu:muteReposts', {
+        uri: postUri,
+        reposterDid: reposterShadow.did,
+        logContext,
+        feedDescriptor: feedFeedback.feedDescriptor,
+      })
+    }
+  }
+
   const onReportMisclassification = () => {
     const url = `https://docs.google.com/forms/d/e/1FAIpQLSd0QPqhNFksDQf1YyOos7r1ofCLvmrKAH1lU042TaS3GAZaWQ/viewform?entry.1756031717=${toShareUrl(
       href,
@@ -729,6 +826,18 @@ let PostMenuItems = ({
           <>
             <Menu.Divider />
             <Menu.Group>
+              {canHideReposter && (
+                <Menu.Item
+                  testID="postDropdownHideRepostsBtn"
+                  label={l`Hide reposts from ${reposterName}`}
+                  onPress={() => void onHideReposts()}>
+                  <Menu.ItemText emoji>
+                    {l`Hide reposts from ${reposterName}`}
+                  </Menu.ItemText>
+                  <Menu.ItemIcon icon={RepostStrikeIcon} position="right" />
+                </Menu.Item>
+              )}
+
               {!isAuthor && (
                 <>
                   <Menu.Item

--- a/src/components/PostControls/PostMenu/index.tsx
+++ b/src/components/PostControls/PostMenu/index.tsx
@@ -1,6 +1,7 @@
 import {memo, useMemo, useState} from 'react'
 import {type Insets} from 'react-native'
 import {
+  type AppBskyActorDefs,
   type AppBskyFeedDefs,
   type AppBskyFeedPost,
   type AppBskyFeedThreadgate,
@@ -27,6 +28,7 @@ let PostMenuButton = ({
   timestamp,
   threadgateRecord,
   onShowLess,
+  reposter,
   hitSlop,
   logContext,
   forceGoogleTranslate,
@@ -41,6 +43,7 @@ let PostMenuButton = ({
   timestamp: string
   threadgateRecord?: AppBskyFeedThreadgate.Record
   onShowLess?: (interaction: AppBskyFeedDefs.Interaction) => void
+  reposter?: AppBskyActorDefs.ProfileViewBasic
   hitSlop?: Insets
   logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
   forceGoogleTranslate: boolean
@@ -90,6 +93,7 @@ let PostMenuButton = ({
             timestamp={timestamp}
             threadgateRecord={threadgateRecord}
             onShowLess={onShowLess}
+            reposter={reposter}
             logContext={logContext}
             forceGoogleTranslate={forceGoogleTranslate}
           />

--- a/src/components/PostControls/index.tsx
+++ b/src/components/PostControls/index.tsx
@@ -1,6 +1,7 @@
 import {memo, useMemo, useState} from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import {
+  type AppBskyActorDefs,
   type AppBskyFeedDefs,
   type AppBskyFeedPost,
   type AppBskyFeedThreadgate,
@@ -53,6 +54,7 @@ let PostControls = ({
   threadgateRecord,
   onShowLess,
   viaRepost,
+  reposter,
   variant,
   forceGoogleTranslate = false,
 }: {
@@ -69,6 +71,7 @@ let PostControls = ({
   threadgateRecord?: AppBskyFeedThreadgate.Record
   onShowLess?: (interaction: AppBskyFeedDefs.Interaction) => void
   viaRepost?: {uri: string; cid: string}
+  reposter?: AppBskyActorDefs.ProfileViewBasic
   variant?: 'compact' | 'normal' | 'large'
   forceGoogleTranslate?: boolean
 }): React.ReactNode => {
@@ -345,6 +348,7 @@ let PostControls = ({
           timestamp={post.indexedAt}
           threadgateRecord={threadgateRecord}
           onShowLess={onShowLess}
+          reposter={reposter}
           hitSlop={{
             left: secondaryControlSpacingStyles.gap / 2,
           }}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -85,7 +85,17 @@ export function Icon({icon}: {icon?: React.ComponentType<SVGIconProps>}) {
   return <IconComponent size="md" fill={styles.iconColor} />
 }
 
-export function Text({children}: {children: React.ReactNode}) {
+export function Text({
+  children,
+  emoji,
+}: {
+  children: React.ReactNode
+  /**
+   * Forwarded to the underlying `Text`. Enable when children may contain
+   * emoji, e.g. user-generated text such as display names.
+   */
+  emoji?: boolean
+}) {
   const {type} = useContext(ToastConfigContext)
   const {textColor} = useToastStyles({type})
   const {fontScaleCompensation} = useToastFontScaleCompensation()
@@ -99,6 +109,7 @@ export function Text({children}: {children: React.ReactNode}) {
         },
       ]}>
       <BaseText
+        emoji={emoji}
         selectable={false}
         style={[
           a.text_md,
@@ -179,7 +190,6 @@ export function Action(
   }, [t, type])
 
   const onPress = (e: GestureResponderEvent) => {
-    console.log('Toast Action pressed, dismissing toast', id)
     dismiss(id)
     props.onPress?.(e)
   }

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -211,6 +211,17 @@ export function usePostAuthorShadowFilter(data?: FeedPage[]) {
   }, [authors])
 }
 
+/**
+ * Point-in-time, non-reactive read of the shadow data recorded for a profile
+ * object, or undefined if none has been written. For use outside of render,
+ * e.g. in callbacks that outlive their component.
+ */
+export function getProfileShadow(
+  profile: bsky.profile.AnyProfileView,
+): Partial<ProfileShadow> | undefined {
+  return shadows.get(profile)
+}
+
 export function updateProfileShadow(
   queryClient: QueryClient,
   did: string,

--- a/src/state/queries/explore-feed-previews.tsx
+++ b/src/state/queries/explore-feed-previews.tsx
@@ -425,6 +425,12 @@ export function* findAllProfilesInQueryData(
         if (item.post.author.did === did) {
           yield item.post.author
         }
+        if (
+          AppBskyFeedDefs.isReasonRepost(item.reason) &&
+          item.reason.by.did === did
+        ) {
+          yield item.reason.by
+        }
         const quotedPost = getEmbeddedPost(item.post.embed)
         if (quotedPost?.author.did === did) {
           yield quotedPost.author

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -568,6 +568,12 @@ export function* findAllProfilesInQueryData(
         if (item.post.author.did === did) {
           yield item.post.author
         }
+        if (
+          AppBskyFeedDefs.isReasonRepost(item.reason) &&
+          item.reason.by.did === did
+        ) {
+          yield item.reason.by
+        }
         const quotedPost = getEmbeddedPost(item.post.embed)
         if (quotedPost?.author.did === did) {
           yield quotedPost.author

--- a/src/style.css
+++ b/src/style.css
@@ -210,6 +210,7 @@ input:focus {
 }
 .dropdown-menu-constrain-size > * {
   max-height: var(--radix-dropdown-menu-content-available-height);
+  max-width: var(--radix-dropdown-menu-content-available-width);
 }
 
 .force-no-clicks > *,

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -897,6 +897,7 @@ let PostFeed = ({
             }
             isParentBlocked={item.isParentBlocked}
             isParentNotFound={item.isParentNotFound}
+            isAuthorFeed={feedType === 'author'}
             hideTopBorder={rowIndex === 0 && indexInSlice === 0}
             rootPost={slice.items[0].post}
             onShowLess={onPressShowLess}

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -75,6 +75,13 @@ interface FeedItemProps {
   hideTopBorder?: boolean
   isParentBlocked?: boolean
   isParentNotFound?: boolean
+  /**
+   * Author feeds show the account's own reposts regardless of a repost mute,
+   * so the "Hide reposts from ..." menu item is suppressed there - it would
+   * leave the rows in place while the header gains a "Reposts Hidden" pill,
+   * and the profile's own menu already offers the same action.
+   */
+  isAuthorFeed?: boolean
 }
 
 export function PostFeedItem({
@@ -92,6 +99,7 @@ export function PostFeedItem({
   hideTopBorder,
   isParentBlocked,
   isParentNotFound,
+  isAuthorFeed,
   rootPost,
   onShowLess,
 }: FeedItemProps & {
@@ -130,6 +138,7 @@ export function PostFeedItem({
           hideTopBorder={hideTopBorder}
           isParentBlocked={isParentBlocked}
           isParentNotFound={isParentNotFound}
+          isAuthorFeed={isAuthorFeed}
           rootPost={rootPost}
           onShowLess={onShowLess}
         />
@@ -155,6 +164,7 @@ let FeedItemInner = ({
   hideTopBorder,
   isParentBlocked,
   isParentNotFound,
+  isAuthorFeed,
   rootPost,
   onShowLess,
 }: FeedItemProps & {
@@ -299,6 +309,11 @@ let FeedItemInner = ({
     }
   }, [reason])
 
+  const reposter =
+    !isAuthorFeed && AppBskyFeedDefs.isReasonRepost(reason)
+      ? reason.by
+      : undefined
+
   const threadgateHiddenReplies = useMergedThreadgateHiddenReplies({
     threadgateRecord,
   })
@@ -441,6 +456,7 @@ let FeedItemInner = ({
               threadgateRecord={threadgateRecord}
               onShowLess={onShowLess}
               viaRepost={viaRepost}
+              reposter={reposter}
             />
           </View>
 


### PR DESCRIPTION
> [!NOTE]
> **Claude Code wrote the PR and the description, with light edits by me.**
>
> **I tested this on web but not on Android or iOS.**

### Summary

Adds a way to stop seeing reposts from a specific account directly from the feed, without visiting their profile.

### What this does

When a post in a feed is a repost, the post's `...` menu now shows **"Hide reposts from {displayname}"** — targeting the account that created the repost (`reason.by`).

Selecting it:

- Mutes reposts from that account using the existing repost-only mute (`agent.mute(did, {onlyReposts: true})`).
- Shows a toast — "Reposts from {displayname} will be hidden in feeds" — with an **Undo** action. Selecting **Undo** removes the mute and shows a confirmation toast saying "Reposts from {displayname} will be shown in feeds". If the account was fully muted while the toast was up, **Undo** quietly does nothing (see "Undo vs. a concurrent full mute" below).

Already-loaded rows are intentionally left in place; the appview filters the account's reposts out of subsequent feed fetches.

### How it works

- **Reposter plumbing** – `PostControls` only received `viaRepost: {uri, cid}`, which drops the reposter's profile. A new optional `reposter?: ProfileViewBasic` is derived in `PostFeedItem` from the slice's `ReasonRepost` and threaded through `PostControls` → `PostMenuButton` → `PostMenuItems`. Threads, standalone posts and the video feed don't pass it, so the item is feed-only.
- **Not on author feeds** (`PostFeed.tsx`, `PostFeedItem.tsx`) – `PostFeed` passes down whether it is rendering an author feed; `PostFeedItem` skips `reposter` for those, suppressing the item through the same "no reposter, no item" path.
  - A profile's Posts tab shows that account's reposts regardless of a repost mute, so the action would leave every row in place while the header gained its "Reposts Hidden" pill.
  - Every repost row there is by the profile owner anyway, so the item could only duplicate the profile menu's "Hide reposts in feeds".
- **Menu item & gating** (`PostMenuItems.tsx`) – rendered first in the moderation group, so it also appears when someone reposts your own post. Hidden for "Reposted by you" rows and when the reposter is already muted, blocked, list-muted or repost-muted. Same shape as "Mute account": immediate (no confirmation prompt), error toast on failure, analytics in `finally`.
- **Emoji-safe name rendering** – display names often contain emoji, which only render correctly on iOS when the Typography `Text` `emoji` prop is set. `Menu.ItemText` and `Toast.Text` gain an optional `emoji` prop forwarded to their underlying `Text`, enabled wherever the name appears.
  - That handling only applies to plain string children, so the name-bearing strings use the `l` macro rather than `Trans`, and both toasts use the `Toast.Outer` JSX form of `Toast.show`.
- **Menu width cap & text wrapping on web — affects all existing menus** – Radix's popper enforces `min-width: max-content` and web `ItemText` had no line or width constraint, so an unbreakable token of user text (a long hashtag in "See #{tag} posts", or now this item's display name in certain cases) could widen the dropdown past a narrow viewport.
  - The dropdown's `constrain-size` CSS caps `max-width` to Radix's available-width variable — the actual overflow fix.
  - `ItemText` gets `numberOfLines={2}` plus `word-break: break-word`, so labels wrap at the cap instead of truncating: long translations wrap as before, unbreakable tokens break mid-token, anything past two lines clamps with a tail ellipsis.
  - Native is unchanged (one line, middle ellipsis, in a full-width sheet), and on all platforms full strings stay available to assistive tech via each item's `label`. The web emoji picker shares `constrain-size`, where the cap is a no-op — it only renders at `gtPhone` widths.
- **Shadow-cache reactivity** (`post-feed.ts`, `explore-feed-previews.tsx`) – `findAllProfilesInQueryData` now also yields `item.reason.by`, so `mutedOnlyReposts` shadow updates reach the reposter objects held by feed rows: after one press the item disappears from that account's other loaded reposts, and returns on Undo. Both caches that back repost rows need the branch — Search/Explore feed previews render the same component from their own cache, and without it the item stayed on offer there after a successful mute.
- **Undo vs. a concurrent full mute** (`profile-shadow.ts`, `PostMenuItems.tsx`) – undo issues the generic unmute, which clears *any* mute on the account, so a full mute applied while the toast is up would be cleared by an Undo that never created it.
  - The Undo callback outlives the menu, so state captured at render time can't see that newer mute. A new non-hook `getProfileShadow()` reads the shadow cache at press time, keyed on the same `reason.by` object the generator above registers.
  - If `muted` was set in the meantime, Undo no-ops silently and the reposts stay hidden by the stronger mute. Best-effort: a feed refetch inside the window can drop the shadow entry, falling back to a plain undo. The `postMenu:unmuteReposts` metric still fires.
- **Analytics** – new `postMenu:muteReposts` / `postMenu:unmuteReposts` keys carrying `reposterDid`, complementing the `profile:muteReposts` events fired inside the mutation queue.
- **Drive-by** – removed a pre-existing stray `console.log` in `Toast.Action` that fired on every toast-action press in production.

### Test plan

- [ ] On a "Reposted by X" feed row – except on a profile's Posts tab – the menu shows the new item with the strike-repost icon. Pressing it shows the Undo toast and a feed refresh drops X's reposts while keeping X's own posts. Non-repost, pinned, and "Reposted by you" rows show no item.
- [ ] On web at a narrow viewport width: the "Hide reposts from …" item for a long display name wraps to at most two lines (tail ellipsis beyond that) and the dropdown stays within the viewport; an unbreakable token (e.g. "See #… posts" for a long hashtag) breaks mid-token instead of widening the menu; multi-word labels and long translations wrap as before.
- [ ] On iOS, with a reposter whose display name contains emoji: the menu label and both toasts render the emoji correctly, and a long emoji-heavy name still middle-ellipsizes cleanly in the menu row.
- [ ] Undo race: hide reposts from X, then fully mute X from their profile while the toast is still up, then press Undo — X stays muted, no unmute request is sent, and no confirmation toast appears.