### PR TITLE
Add NUX warning iOS users < 16.4 about increased requirement

### DIFF
--- a/src/components/dialogs/nuxs/IosVersionSunsetAnnouncement.tsx
+++ b/src/components/dialogs/nuxs/IosVersionSunsetAnnouncement.tsx
@@ -1,0 +1,84 @@
+import {View} from 'react-native'
+import {Trans, useLingui} from '@lingui/react/macro'
+
+import {atoms as a, useTheme} from '#/alf'
+import * as Dialog from '#/components/Dialog'
+import {useNuxDialogContext} from '#/components/dialogs/nuxs'
+import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
+import * as Prompt from '#/components/Prompt'
+import {IOS_MAJOR_VERSION, IS_E2E, IS_UNSUPPORTED_IOS} from '#/env'
+import {createIsEnabledCheck} from './utils'
+
+export const enabled = createIsEnabledCheck(() => {
+  return !IS_E2E && IS_UNSUPPORTED_IOS
+})
+
+/**
+ * Warns users below the upcoming iOS 16.4 deployment target that they are about
+ * to stop receiving app updates.
+ *
+ * Users on iOS 16.0-16.3 can always reach 16.4, so they get an actionable "go
+ * update" message. Users on iOS 15 may be on hardware that cannot go any
+ * further, so their copy leads with the end of updates and mentions updating
+ * only as a possibility.
+ */
+export function IosVersionSunsetAnnouncement() {
+  const t = useTheme()
+  const {t: l} = useLingui()
+  const nuxDialogs = useNuxDialogContext()
+  const control = Dialog.useDialogControl()
+
+  Dialog.useAutoOpen(control)
+
+  /*
+   * Gated to below 16.4, so being on iOS 16 at all means the device is one
+   * minor update away from staying supported.
+   */
+  const isOnIos16 = IOS_MAJOR_VERSION >= 16
+
+  return (
+    <Prompt.Outer
+      control={control}
+      onClose={() => {
+        nuxDialogs.dismissActiveNux()
+      }}>
+      <View style={[a.pb_sm]}>
+        <WarningIcon size="lg" fill={t.palette.negative_400} />
+      </View>
+
+      <Prompt.Content>
+        <Prompt.TitleText>
+          {isOnIos16 ? (
+            <Trans comment="Shown to users on iOS 16.0-16.3, who can update to a supported version.">
+              iOS update needed to keep receiving app updates
+            </Trans>
+          ) : (
+            <Trans comment="Shown to users on iOS 15, whose device may not be able to update any further.">
+              Bluesky is ending support for iOS 15
+            </Trans>
+          )}
+        </Prompt.TitleText>
+        <Prompt.DescriptionText>
+          {isOnIos16 ? (
+            <Trans comment="Shown to users on iOS 16.0-16.3, who can update to a supported version.">
+              Our next app update will require iOS 16.4 or later. Your device
+              supports it, so please open iOS Settings and update iOS to keep
+              receiving new features and fixes.
+            </Trans>
+          ) : (
+            <Trans comment="Shown to users on iOS 15, whose device may not be able to update any further.">
+              Our next app update will require iOS 16.4 or later. You can keep
+              using the Bluesky iOS app, but this will be the last version your
+              device receives on iOS 15. If your device can update to a newer
+              version of iOS, updating will keep new features and fixes coming.
+            </Trans>
+          )}
+        </Prompt.DescriptionText>
+      </Prompt.Content>
+
+      <Prompt.Actions>
+        <Prompt.Action cta={l`Got it`} onPress={() => {}} />
+      </Prompt.Actions>
+    </Prompt.Outer>
+  )
+}

--- a/src/components/dialogs/nuxs/index.tsx
+++ b/src/components/dialogs/nuxs/index.tsx
@@ -26,6 +26,10 @@ import {
   enabled as isInviteFriendsAnnouncementEnabled,
   InviteFriendsAnnouncement,
 } from '#/components/dialogs/nuxs/InviteFriendsAnnouncement'
+import {
+  enabled as isIosVersionSunsetAnnouncementEnabled,
+  IosVersionSunsetAnnouncement,
+} from '#/components/dialogs/nuxs/IosVersionSunsetAnnouncement'
 import {isSnoozed, snooze, unsnooze} from '#/components/dialogs/nuxs/snoozing'
 import {type EnabledCheckProps} from '#/components/dialogs/nuxs/utils'
 import {useAnalytics} from '#/analytics'
@@ -40,6 +44,10 @@ const queuedNuxs: {
   id: Nux
   enabled?: (props: EnabledCheckProps) => boolean
 }[] = [
+  {
+    id: Nux.IosVersionSunset164,
+    enabled: isIosVersionSunsetAnnouncementEnabled,
+  },
   {
     id: Nux.GroupChatsAnnouncement,
     enabled: isGroupChatsAnnouncementEnabled,
@@ -194,6 +202,9 @@ function Inner({
   return (
     <Context.Provider value={ctx}>
       {/*For example, activeNux === Nux.NeueTypography && <NeueTypography />*/}
+      {activeNux === Nux.IosVersionSunset164 && (
+        <IosVersionSunsetAnnouncement />
+      )}
       {activeNux === Nux.GroupChatsAnnouncement && <GroupChatsAnnouncement />}
       {/*
         Mounted unconditionally: it gates the announcement on `activeNux`

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -17,6 +17,15 @@ export const IOS_MAJOR_VERSION: number =
     ? parseInt(Platform.Version.split('.')[0], 10)
     : 0
 /**
+ * The minor version number of the current iOS device (e.g. `4` for iOS 16.4),
+ * or `0` on non-iOS platforms. A missing minor segment is treated as `.0`,
+ * since `Platform.Version` is not guaranteed to have more than one segment.
+ */
+export const IOS_MINOR_VERSION: number =
+  Platform.OS === 'ios' && typeof Platform.Version === 'string'
+    ? parseInt(Platform.Version.split('.')[1] ?? '0', 10) || 0
+    : 0
+/**
  * The Android API level of the current device (e.g. `23` for Android 6.0), or
  * `0` on non-Android platforms. Note this is the API level, not the marketing
  * version.
@@ -67,3 +76,18 @@ export const IS_LIQUID_GLASS: boolean = IOS_MAJOR_VERSION >= 26
 // So we can avoid attempting on-device translation when we know it's unsupported.
 export const IS_TRANSLATION_SUPPORTED: boolean =
   (IS_IOS && IOS_MAJOR_VERSION >= 18) || (IS_ANDROID && ANDROID_API_LEVEL > 22)
+/*
+ * True on iOS devices below the 16.4 deployment target, i.e. devices that will
+ * stop receiving app updates, so we can warn these users ahead of the bump.
+ *
+ * Note that no iPhone is capped between 16.0 and 16.3 - the oldest hardware
+ * supporting iOS 16 reaches 16.7.x - so every device already on iOS 16 can get
+ * to 16.4 by updating. Devices on iOS 15 may or may not be able to, and we
+ * deliberately don't try to tell those two groups apart (it would mean
+ * maintaining a hardware allowlist, and `Device.modelId` reports the host arch
+ * rather than the simulated device, so the branch would be untestable).
+ */
+export const IS_UNSUPPORTED_IOS: boolean =
+  IS_IOS &&
+  (IOS_MAJOR_VERSION < 16 ||
+    (IOS_MAJOR_VERSION === 16 && IOS_MINOR_VERSION < 4))

--- a/src/env/index.web.ts
+++ b/src/env/index.web.ts
@@ -20,6 +20,11 @@ export const APP_METADATA = `${BUNDLE_IDENTIFIER.slice(0, 7)} (${__DEV__ ? 'dev'
  */
 export const IOS_MAJOR_VERSION: number = 0
 /**
+ * The minor version number of the current iOS device, or `0` on non-iOS
+ * platforms (always `0` on web).
+ */
+export const IOS_MINOR_VERSION: number = 0
+/**
  * The Android API level of the current device, or `0` on non-Android platforms
  * (always `0` on web).
  */
@@ -60,3 +65,4 @@ export const IS_HIGH_DPI: boolean = window.matchMedia(
 ).matches
 export const IS_LIQUID_GLASS: boolean = false
 export const IS_TRANSLATION_SUPPORTED: boolean = false
+export const IS_UNSUPPORTED_IOS: boolean = false

--- a/src/state/queries/nuxs/definitions.ts
+++ b/src/state/queries/nuxs/definitions.ts
@@ -17,6 +17,7 @@ export enum Nux {
   DraftsAnnouncement = 'DraftsAnnouncement',
   GroupChatsAnnouncement = 'GroupChatsAnnouncement',
   InviteFriendsAnnouncement = 'InviteFriendsAnnouncement',
+  IosVersionSunset164 = 'IosVersionSunset164',
 
   /*
    * Blocking announcements. New IDs are required for each new announcement.
@@ -87,6 +88,10 @@ export type AppNux = BaseNux<
       id: Nux.InviteFriendsAnnouncement
       data: undefined
     }
+  | {
+      id: Nux.IosVersionSunset164
+      data: undefined
+    }
 >
 
 export const NuxSchemas: Record<Nux, zod.ZodObject<any> | undefined> = {
@@ -105,4 +110,5 @@ export const NuxSchemas: Record<Nux, zod.ZodObject<any> | undefined> = {
   [Nux.DraftsAnnouncement]: undefined,
   [Nux.GroupChatsAnnouncement]: undefined,
   [Nux.InviteFriendsAnnouncement]: undefined,
+  [Nux.IosVersionSunset164]: undefined,
 }


### PR DESCRIPTION
## Summary

Warns iOS users below 16.4 that they are about to stop receiving app updates, ahead of the deployment target bump in the release after 1.130.

## Detecting the version

`Platform.Version` on iOS is a version string, so the existing `IOS_MAJOR_VERSION` can't distinguish 16.4 from 16.0. This adds `IOS_MINOR_VERSION` and `IS_UNSUPPORTED_IOS` to `#/env`, alongside the existing `IS_LIQUID_GLASS` / `IS_TRANSLATION_SUPPORTED` flags, with `0`/`false` counterparts in `index.web.ts` so the check compiles out on web.

## Two variants

No iPhone is capped between 16.0 and 16.3 — the oldest hardware supporting iOS 16 reaches 16.7.x — so the OS version alone tells us whether the user can act on the warning:

| Running | Message |
| --- | --- |
| iOS 16.0–16.3 | "iOS update needed to keep receiving app updates" — the device supports 16.4, so it asks them to update iOS. |
| iOS 15 | "Bluesky is ending support for iOS 15" — the device may not be able to update any further, so it leads with the end of updates and treats updating as a possibility rather than an instruction. |

Splitting on OS version rather than device model is deliberate. Identifying hardware would mean maintaining an allowlist, and `expo-device`'s `modelId` is raw `utsname.machine`, which reports the host architecture on a simulator — so a model-based branch would be untestable.

## Delivery

Uses the existing NUX queue, so it shows once per account and dismissal persists server-side. There are no new native dependencies, so this could ship as an OTA against 1.130 — the last version supporting iOS 15.1.

## Testing

Both branches are reachable on stock simulator runtimes (iOS 15.x and 16.0–16.3). In dev, `window.clearNuxDialog('IosVersionSunset164')` re-shows the dialog.